### PR TITLE
Added link to Standard Unix Notes - a GPG encrypted notes/notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ If you have any suggestion or want your project listed here, drop me an email at
 * [dijo](https://github.com/NerdyPepper/dijo) - Scriptable, curses-based, digital habit tracker.
 * [dn](https://github.com/tomlockwood/dn) - Daily notes command line tool.
 * [ledger](http://ledger-cli.org/) - A powerful, double-entry accounting system from the command-line; it uses a simple yet powerful text syntax to specify the items to account.
+* [notes](https://github.com/Standard-Unix-Notes/unix-notes) - GPG Encrypted Notes/Notebook manager for BSD/Linux
 * [posce](https://github.com/posce/posce) - A note-taking toolkit for your command line.
 * [Qalculate](https://qalculate.github.io/) - Multi-purpose calculator with customizable functions, units, arbitrary precision, plotting (it includes a GUI).
 * [Translate Shell](https://www.soimort.org/translate-shell/) - Command-line translator using Google Translate, Bing Translator, Yandex.Translate, etc.


### PR DESCRIPTION
Hi

I've suggested Standard Unix Notes - a GPG encrypted ntoes/notebook manager that runs in any Unix/BSD/Linux etc that supports GnuPG.

It is written in the Bourne shell avoiding Bash as that is not installed by default on some machines.