### PR TITLE
add pyutube

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -1502,3 +1502,4 @@ devops,stern,,https://github.com/stern/stern,Multi pod and container log tailing
 git,gh,https://cli.github.com/,https://github.com/cli/cli,"GitHub's official tool to manage repos, issues, projects, gists and much more."
 cheatsheet,tlrc,https://tldr.sh/tlrc/,https://github.com/tldr-pages/tlrc,Official tldr client written in Rust.
 networking,netscanner,,https://github.com/Chleba/netscanner,"All-in-one network scanning tool."
+video,Pyutube,,https://github.com/Hetari/pyutube,"pyutube is a simple cli tool to download YouTube video shorts and playlist in just one click"


### PR DESCRIPTION
`pyutube` is a simple cli tool to download YouTube video shorts and playlist in just one click, so I put it in `Video` category.