### PR TITLE
Add x-cmd to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1575,6 +1575,7 @@ System management tools, such as for brightness control, dotfile and environment
 * [viewport-list-cli](https://github.com/kevva/viewport-list-cli) - Return a list of devices and their viewports.
 * [YAS-BDSM](https://github.com/sebastiancarlos/yas-bdsm) - YAS-BDSM (Yet Another Stow-Based Dotfiles System Manager): a minimal, UNIX-based, cross-platform, hierarchical dotfiles manager.
 * [ydf](https://github.com/yunielrc/ydf) - A disruptive dotfiles manager+. Be ready to work in just a few minutes on your Fresh OS.
+* [x-cmd](https://github.com/x-cmd/x-cmd) - A toolset implemented using posix shell and awk. It is very small in size and offers many interesting features. 
 
 ## <a name="terminal"></a>Terminals
 


### PR DESCRIPTION
Hi. Thank you for this collection of useful CLI Apps!
I want to add x-cmd to the list.
I have searched the PRs of this repo and believe that this is not a duplicate.

x-cmd is a toolset implemented using posix shell and awk. It is very small in size and offers many interesting features.This is our official website: https://www.x-cmd.com/

Tools Provided by x-cmd:

Wrappers for Common Commands (e.g., cd, ip, ps, tar, apt, brew): These wrapped commands are more intelligent and easier to use compared to the native commands.
Lightweight Package Management Tool: We have implemented a lightweight package management tool using shell and awk. Through it, you can quickly obtain most common software tools, such as jq, 7za, bat, nvim, python, node, go, etc.
CLI for Useful Websites (e.g., github.com, cht.sh): We have wrapped their APIs using shell and awk for daily use and to obtain corresponding services in scripts.
AI Tools: We provide CLIs for ChatGPT, Gemini, Jina.ai, etc., and have wrapped corresponding shortcut commands for different application scenarios, such as @gemini for chatting with Gemini AI and @zh for using AI to translate specified content or command results.