### PR TITLE
add gowall

### DIFF
--- a/README.md
+++ b/README.md
@@ -949,7 +949,7 @@ Applications to process images, colors, and ASCII art.
 * [gifgen](https://github.com/lukechilds/gifgen) - Simple high quality GIF encoding.
 * [gifsicle](https://github.com/kohler/gifsicle) - Create, manipulate, and optimize GIF images and animations.
 * [givegif](https://github.com/passy/givegif) - GIFs on the command line.
-* [gowall](https://github.com/Achno/gowall) - Wallpaper Theme converter, color pallete extraction & more
+* [gowall](https://github.com/Achno/gowall) - Wallpaper Theme converter, color palette extraction & more
 * [GraphicsMagick](http://www.graphicsmagick.org/) - Swiss army knife of image processing.
 * [Graphviz](https://graphviz.org/) - Graphviz is open source graph visualization software. It contains several command line tools to generate and manipulate graphs.
 * [haylxon](https://github.com/pwnwriter/haylxon) - Blazing-fast tool to grab screenshots of your domain list right from terminal.

--- a/README.md
+++ b/README.md
@@ -949,6 +949,7 @@ Applications to process images, colors, and ASCII art.
 * [gifgen](https://github.com/lukechilds/gifgen) - Simple high quality GIF encoding.
 * [gifsicle](https://github.com/kohler/gifsicle) - Create, manipulate, and optimize GIF images and animations.
 * [givegif](https://github.com/passy/givegif) - GIFs on the command line.
+* [gowall](https://github.com/Achno/gowall) - Wallpaper Theme converter, color pallete extraction & more
 * [GraphicsMagick](http://www.graphicsmagick.org/) - Swiss army knife of image processing.
 * [Graphviz](https://graphviz.org/) - Graphviz is open source graph visualization software. It contains several command line tools to generate and manipulate graphs.
 * [haylxon](https://github.com/pwnwriter/haylxon) - Blazing-fast tool to grab screenshots of your domain list right from terminal.


### PR DESCRIPTION
## Description 
[gowall](https://github.com/Achno/gowall) is a  tool to convert a Wallpaper's color scheme / palette.

- It has support for  single,batch and a whole directory of images to be converted to  25 themes (catppuccin,nord,solarized etc...)
- Create your own custom theme to convert an image into
- It has terminal image support by supporting the kitty terminal emulator protocol
- Extract the color palette from an image 
- Draw beautiful borders to an image 
- Has wallpapers voted by the community that reset every day , Invert the colors of an image & more 

Now you only need to find a Wallpaper where you like its design and not have to worry about its colors