### PR TITLE
Add kubefwd - Kubernetes bulk port forwarding with TUI

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -1492,6 +1492,7 @@ system,direnv,https://direnv.net/,https://github.com/direnv/direnv,Loads and unl
 networking,doggo,https://doggo.mrkaran.dev/,https://github.com/mr-karan/doggo,"DNS client for humans. Features include: colors, tabular and JSON formats, and reverse DNS lookup."
 package-manager,krew,https://krew.sigs.k8s.io/,https://github.com/kubernetes-sigs/krew,Find and install kubectl plugins.
 devops,kubectx,https://kubectx.dev/,https://github.com/ahmetb/kubectx,Quickly switch between clusters and namespaces in kubectl.
+devops,kubefwd,https://kubefwd.com,https://github.com/txn2/kubefwd,Bulk port forwarding Kubernetes services to localhost with unique IPs per service and interactive TUI.
 package-manager,mise,https://mise.jdx.dev/,https://github.com/jdx/mise,"A development environment setup tool: dev tools, env vars, and task runner. Like `asdf` + `direnv` + `make`."
 devops,stern,,https://github.com/stern/stern,Multi pod and container log tailing for Kubernetes.
 git,gh,https://cli.github.com/,https://github.com/cli/cli,"GitHub's official tool to manage repos, issues, projects, gists and much more."


### PR DESCRIPTION
kubefwd is a CLI tool for bulk-forwarding Kubernetes services to localhost. Each service gets a unique loopback IP (127.x.x.x), enabling multiple services on the same port without conflicts.

Features:
- Unique IP per service (multiple DBs on port 3306, web services on port 80)
- Interactive TUI with traffic monitoring
- Auto-reconnect with exponential backoff
- Automatic /etc/hosts management

Repository: https://github.com/txn2/kubefwd
Website: https://kubefwd.com
Stars: 4,000+