### PR TITLE
Add renamed.to to File renamers

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -1313,6 +1313,7 @@ online,pure-recipe,,https://github.com/atiumcache/pure-recipe,"Input a recipe UR
 versioning,Jujutsu,,https://github.com/martinvonz/jj,A Git-compatible VCS that is both simple and powerful.
 text-search-replace,Rep,,https://github.com/robenkleene/rep-grep,"Rep is a command-line utility that takes grep-formatted lines via standard input, and performs a find-and-replace on them."
 file-renamer,Ren,,https://github.com/robenkleene/ren-find,"Ren is a command-line utility that takes find-formatted lines via standard input, and batch renames them."
+file-renamer,renamed.to,https://www.renamed.to/cli,https://github.com/upspawn/cli.renamed.to,AI-powered file renamer that analyzes document content (PDFs, scans, images) and generates descriptive filenames in bulk.
 conversion,transflac,,https://bitbucket.org/gbcox/transflac.git/,A repository containing a series of utilities to assist in the maintenance and organization of FLAC based music collections.
 programming,scriptisto,,https://github.com/igor-petruk/scriptisto,"A language-agnostic ""shebang interpreter"" that enables you to write scripts in compiled languages."
 utility,gentoo-install,,https://github.com/oddlama/gentoo-install,"This project aspires to be your favorite way to install gentoo. It aims to provide a smooth installation experience, both for beginners and experts. You may configure it by using a menuconfig-inspired interface or simply via a config file."


### PR DESCRIPTION
Add [renamed.to](https://github.com/upspawn/cli.renamed.to) to the **file-renamer** category.

## Entry details

- **Category**: `file-renamer`
- **Name**: `renamed.to`
- **Homepage**: https://www.renamed.to/cli
- **Git**: https://github.com/upspawn/cli.renamed.to
- **Description**: AI-powered file renamer that analyzes document content (PDFs, scans, images) and generates descriptive filenames in bulk.

## About renamed.to

`renamed.to` is a CLI that uses AI to rename files based on their actual content. It reads PDFs, images, and other documents via OCR, then generates descriptive filenames automatically. Available via npm (`npm i -g @renamed-to/cli`) and Homebrew (`brew install renamed-to/cli/renamed`).