### PR TITLE
Add snav to data/apps.csv

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -1946,6 +1946,7 @@ screensaver,gitlogue,,https://github.com/unhappychoice/gitlogue,"A cinematic Git
 devops,TFTUI,,https://github.com/idoavrah/terraform-tui,TUI to view and interact with Terraform state.
 package-manager,ToolUI,,https://github.com/jinek/ToolUI,TUI to manage dotnet tools.
 programming,Tokui,,https://github.com/zdyxry/tokui,An interactive TUI for visualizing code statistics from tockei.
+programming,snav,,https://github.com/oomathias/snav,"Interactive symbol finder for codebases with fuzzy search, syntax-highlighted preview, and quick file:line:col jumps."
 vm,VCTUI,,https://github.com/thebsdbox/vctui,"Console interface for vCenter: create, delete and search virtual machines and power management."
 devops,Ducker,,https://github.com/robertpsoane/ducker,TUI for managing docker containers.
 devops,E1S,,https://github.com/keidarcy/e1s,TUI for browsing and managing AWS ECS resources.


### PR DESCRIPTION
## Summary

- Add `snav` to `data/apps.csv` under the `programming` category.
- Keep the change scoped to the CSV source file only.

## Why

`snav` is a terminal code-navigation tool that helps developers find symbols quickly in large codebases.

## Entry Added

- `name`: snav
- `homepage`: https://github.com/oomathias/snav
- `git`: https://github.com/oomathias/snav
- `description`: Interactive symbol finder for codebases with fuzzy search, syntax-highlighted preview, and quick file:line:col jumps.
