### PR TITLE
Add clipslots to Clipboard category

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -1953,3 +1953,4 @@ devops,eks-node-viewer,,https://github.com/awslabs/eks-node-viewer/,Tool for vis
 devops,KDash,,https://github.com/kdash-rs/kdash,A simple and fast terminal dashboard for Kubernetes.
 devops,ktop,,https://github.com/vladimirvivien/ktop,"Tool that displays useful metrics information about nodes, pods, and other workload."
 devops,kubetui,,https://github.com/sarub0b0/kubetui,A TUI tool designed for monitoring Kubernetes resources.
+copy-paste,clipslots,,https://github.com/olafglad/clipSlots,Named clipboard slots with global hotkeys for macOS.


### PR DESCRIPTION
[clipslots](https://github.com/olafglad/clipSlots) is a lightweight clipboard slot manager for macOS with named slots and global hotkeys. Free and MIT-licensed.