### PR TITLE
Add dna-claude-analysis to science category

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -1953,3 +1953,4 @@ devops,eks-node-viewer,,https://github.com/awslabs/eks-node-viewer/,Tool for vis
 devops,KDash,,https://github.com/kdash-rs/kdash,A simple and fast terminal dashboard for Kubernetes.
 devops,ktop,,https://github.com/vladimirvivien/ktop,"Tool that displays useful metrics information about nodes, pods, and other workload."
 devops,kubetui,,https://github.com/sarub0b0/kubetui,A TUI tool designed for monitoring Kubernetes resources.
+science,dna-claude-analysis,,https://github.com/shmlkv/dna-claude-analysis,"Personal genome analysis toolkit that runs Python scripts analyzing raw DNA data across 17 categories (ancestry, health risks, nutrition, pharmacogenomics, etc.) and generates a terminal-style HTML visualization."


### PR DESCRIPTION
## Description

Adds [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) to the **science** category.

**Homepage:** https://github.com/shmlkv/dna-claude-analysis

**Description:** Personal genome analysis toolkit that runs Python scripts analyzing raw DNA data across 17 categories (ancestry, health risks, nutrition, pharmacogenomics, etc.) and generates a terminal-style HTML visualization.

## CSV entry added

```
science,dna-claude-analysis,,https://github.com/shmlkv/dna-claude-analysis,"Personal genome analysis toolkit that runs Python scripts analyzing raw DNA data across 17 categories (ancestry, health risks, nutrition, pharmacogenomics, etc.) and generates a terminal-style HTML visualization."
```

The project is open source, actively maintained, and fits the science category alongside other bioinformatics/scientific CLI tools.