### PR TITLE
Add OpenPaw to AI category

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -1,4 +1,5 @@
 category,name,homepage,git,description
+ai,pawmode,https://www.npmjs.com/package/pawmode,https://github.com/daxaur/openpaw,Turn Claude Code into a personal assistant with 38 skills for email calendar Spotify smart home Slack GitHub and more.
 programming,termfu,,https://github.com/jvalcher/termfu,A multi-language debugger frontend that allows users to create and switch between custom layouts.
 productivity,h-m-m,,https://github.com/nadrad/h-m-m,"h-m-m (pronounced like the interjection ""hmm"") is a simple, fast, keyboard-centric terminal-based tool for working with mind maps."
 productivity,telert,https://github.com/navig-me/telert,https://github.com/navig-me/telert,"Lightweight CLI and Python utility that sends alerts (Telegram, Slack, Teams, Desktop, Audio) when commands complete."


### PR DESCRIPTION
Hi! I'd like to add [OpenPaw](https://github.com/daxaur/openpaw) to the AI / ChatGPT category.

OpenPaw is an open-source CLI tool (`npx pawmode`) that turns Claude Code into a personal assistant with 38 skills — email, calendar, Spotify, smart home, Slack, GitHub, and more. Written in TypeScript, MIT licensed.

Added the following line to `data/apps.csv`:

```
ai,OpenPaw,https://www.npmjs.com/package/pawmode,https://github.com/daxaur/openpaw,Turn Claude Code into a personal assistant with 38 skills including email calendar Spotify smart home Slack and more.
```

Thanks for maintaining this list!