### PR TITLE
Add OpenPaw

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -1,4 +1,5 @@
 category,name,homepage,git,description
+ai,OpenPaw,https://www.npmjs.com/package/pawmode,https://github.com/daxaur/openpaw,"Turns Claude Code into a personal assistant with 38 skills including email, calendar, Spotify, smart home, Slack, and more."
 programming,termfu,,https://github.com/jvalcher/termfu,A multi-language debugger frontend that allows users to create and switch between custom layouts.
 productivity,h-m-m,,https://github.com/nadrad/h-m-m,"h-m-m (pronounced like the interjection ""hmm"") is a simple, fast, keyboard-centric terminal-based tool for working with mind maps."
 productivity,telert,https://github.com/navig-me/telert,https://github.com/navig-me/telert,"Lightweight CLI and Python utility that sends alerts (Telegram, Slack, Teams, Desktop, Audio) when commands complete."


### PR DESCRIPTION
Adding OpenPaw to the AI category.

- **name**: OpenPaw
- **homepage**: https://www.npmjs.com/package/pawmode
- **git**: https://github.com/daxaur/openpaw
- **description**: Turns Claude Code into a personal assistant with 38 skills including email, calendar, Spotify, smart home, Slack, and more.

OpenPaw is an open-source CLI tool (`npx pawmode`) written in TypeScript. It extends Claude Code with practical everyday skills — email, calendar, Spotify, smart home control, Slack, GitHub, and more. MIT licensed.