### PR TITLE
Add tabby to terminal category

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -1953,3 +1953,4 @@ devops,eks-node-viewer,,https://github.com/awslabs/eks-node-viewer/,Tool for vis
 devops,KDash,,https://github.com/kdash-rs/kdash,A simple and fast terminal dashboard for Kubernetes.
 devops,ktop,,https://github.com/vladimirvivien/ktop,"Tool that displays useful metrics information about nodes, pods, and other workload."
 devops,kubetui,,https://github.com/sarub0b0/kubetui,A TUI tool designed for monitoring Kubernetes resources.
+terminal,tabby,,https://github.com/brendandebeasi/tabby,"Tmux plugin with a daemon-driven vertical sidebar and horizontal tab bar UI for window and pane management."


### PR DESCRIPTION
## Summary

Adding [tabby](https://github.com/brendandebeasi/tabby) to the `terminal` category in `data/apps.csv`.

Tabby is a tmux plugin that provides a daemon-driven vertical sidebar and optional horizontal tab bar for window and pane management. It features window grouping with color coding, full mouse support (click, scroll, right-click context menus), and deep linking. Built with Go and Bubble Tea.

- Added to `data/apps.csv` under the `terminal` category
- Follows existing CSV schema: `category,name,homepage,git,description`