### PR TITLE
Add CastLocal to Video category

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -1963,3 +1963,4 @@ editors,maki,https://sr.ht/~bscit/maki/,,A simple text editor with file navigati
 networking,Thymus,,https://github.com/blademd/thymus,An interactive browser & editor for network configuration files.
 editors,Turbo,,https://github.com/magiblot/turbo,"An experimental text editor for the terminal, based on Scintilla and Turbo Vision."
 file-manager,adbtuifm,,https://github.com/darkhz/adbtuifm,"A TUI file manager for the Android Debug Bridge, to make transfers between the device and client easier."
+video,CastLocal,,https://github.com/YuriKovalov22/cast-control,Cast local video files to Chromecast with automatic transcoding. Dual-pane TUI (Far Manager style) and CLI with hardware-accelerated encoding.


### PR DESCRIPTION
## Add CastLocal

Adding CastLocal to the Video category in `data/apps.csv`.

**Entry:**
```
video,CastLocal,,https://github.com/YuriKovalov22/cast-control,Cast local video files to Chromecast with automatic transcoding. Dual-pane TUI (Far Manager style) and CLI with hardware-accelerated encoding.
```

### About CastLocal

CastLocal is a CLI and TUI for casting local video files to Chromecast devices. It auto-discovers devices on the network, probes video formats, and if the format isn't natively supported (MKV, AVI, etc.), transcodes on-the-fly using ffmpeg with HLS segmentation — so playback starts in seconds.

- **CLI**: `cast movie.mkv` — auto-discovers devices, full playback controls
- **TUI**: Far Manager-style dual-pane interface with keyboard navigation
- **Hardware-accelerated** H.264 encoding (VideoToolbox on macOS)

Install: `pipx install castlocal`