### PR TITLE
Add LynxPrompt to AI / ChatGPT category

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -1963,3 +1963,4 @@ editors,maki,https://sr.ht/~bscit/maki/,,A simple text editor with file navigati
 networking,Thymus,,https://github.com/blademd/thymus,An interactive browser & editor for network configuration files.
 editors,Turbo,,https://github.com/magiblot/turbo,"An experimental text editor for the terminal, based on Scintilla and Turbo Vision."
 file-manager,adbtuifm,,https://github.com/darkhz/adbtuifm,"A TUI file manager for the Android Debug Bridge, to make transfers between the device and client easier."
+ai,LynxPrompt,https://lynxprompt.com,https://github.com/GeiserX/LynxPrompt,CLI for managing AI IDE configuration files across 30+ coding assistants.


### PR DESCRIPTION
## Summary

- Adds [LynxPrompt](https://github.com/GeiserX/LynxPrompt) to the **AI / ChatGPT** category
- LynxPrompt (`lynxp`) is a CLI tool for managing AI IDE configuration files (rules files, MCP configs, etc.) across 30+ coding assistants including Claude Code, Cursor, Windsurf, GitHub Copilot, and more
- Website: https://lynxprompt.com
- License: GPL-3.0

## Changes

Single line addition to `data/apps.csv` in the `ai` category, following the existing CSV format.