### PR TITLE
Add rootly-cli

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -1973,3 +1973,4 @@ games,botany,,https://github.com/jifunks/botany/,"A command line, realtime, virt
 games,Brick Game emulator,,https://github.com/ilyakurdyukov/brickgame-4bit,Brick Game emulator that uses 4-bit microcontroller from Holtek.
 games,Brogue CE,https://sites.google.com/site/broguegame/,https://github.com/tmewett/BrogueCE,Single-player strategy game set in the halls of a mysterious and randomly-generated dungeon.
 games,csol,,https://github.com/nielssp/csol,"Collection of solitaire/patience games, such as Klondike, FreeCell, Spider, and Yukon."
+devops,rootly,,https://github.com/rootlyhq/rootly-cli,"Manage Rootly incidents, alerts, services, teams, and on-call schedules from the terminal."


### PR DESCRIPTION
Add [rootly-cli](https://github.com/rootlyhq/rootly-cli) to the devops category.

**rootly-cli** is an open-source CLI tool written in Go for managing Rootly incidents, alerts, services, teams, and on-call schedules from the terminal. It supports multiple output formats (table, JSON, YAML, markdown), shell completions, and server-side filtering/pagination.