### PR TITLE
Add Wayback-Archive to backup category

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2013,3 +2013,4 @@ chat,slack-term,,https://github.com/erroneousboat/slack-term,Slack client for th
 games,tinytetris,,https://github.com/taylorconor/tinytetris,80x23 terminal tetris game.
 chat,tgt,,https://github.com/FedericoBruzzone/tgt,A TUI for Telegram written in Rust.
 chat,tuisky,,https://github.com/sugyan/tuisky,TUI client for Bluesky.
+backup,Wayback-Archive,,https://github.com/GeiserX/Wayback-Archive,"Downloads complete websites from the Wayback Machine with full asset preservation for offline viewing, rewriting URLs to relative paths and cleaning up archive artifacts."


### PR DESCRIPTION
## Summary

- Adds [Wayback-Archive](https://github.com/GeiserX/Wayback-Archive) to the `data/apps.csv` file under the **backup** category.
- Wayback-Archive is an open-source Python CLI tool (GPL-3.0) that downloads complete websites from the Wayback Machine with full asset preservation for offline viewing, including URL rewriting and archive artifact cleanup.
- Entry added to `data/apps.csv` only (not the README), following the established CSV format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)