### PR TITLE
Add LynxPrompt to AI / ChatGPT category

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2013,3 +2013,4 @@ chat,slack-term,,https://github.com/erroneousboat/slack-term,Slack client for th
 games,tinytetris,,https://github.com/taylorconor/tinytetris,80x23 terminal tetris game.
 chat,tgt,,https://github.com/FedericoBruzzone/tgt,A TUI for Telegram written in Rust.
 chat,tuisky,,https://github.com/sugyan/tuisky,TUI client for Bluesky.
+ai,LynxPrompt,https://github.com/GeiserX/LynxPrompt,https://github.com/GeiserX/LynxPrompt,"Self-hostable AI config management platform for teams. Manages AGENTS.md, CLAUDE.md, .cursor/rules/, slash commands, and 30+ formats. Next.js, PostgreSQL, GPL-3.0."


### PR DESCRIPTION
## Summary

- Adds [LynxPrompt](https://github.com/GeiserX/LynxPrompt) to the **AI / ChatGPT** category
- LynxPrompt is a self-hostable AI config management platform for teams that manages AGENTS.md, CLAUDE.md, .cursor/rules/, slash commands, and 30+ formats
- Built with Next.js and PostgreSQL, licensed under GPL-3.0
