### PR TITLE
Add Wayback-Archive to Backup category

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2013,3 +2013,4 @@ chat,slack-term,,https://github.com/erroneousboat/slack-term,Slack client for th
 games,tinytetris,,https://github.com/taylorconor/tinytetris,80x23 terminal tetris game.
 chat,tgt,,https://github.com/FedericoBruzzone/tgt,A TUI for Telegram written in Rust.
 chat,tuisky,,https://github.com/sugyan/tuisky,TUI client for Bluesky.
+backup,Wayback-Archive,https://github.com/GeiserX/Wayback-Archive,https://github.com/GeiserX/Wayback-Archive,"Download complete websites from the Wayback Machine with full asset preservation for offline viewing."


### PR DESCRIPTION
## Summary

- Adds [Wayback-Archive](https://github.com/GeiserX/Wayback-Archive) to the **Backup** category
- Downloads complete websites from the Wayback Machine with full asset preservation for offline viewing
