### PR TITLE
Add duplicacy-cli-cron and duplicacy-exporter

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2013,3 +2013,5 @@ chat,slack-term,,https://github.com/erroneousboat/slack-term,Slack client for th
 games,tinytetris,,https://github.com/taylorconor/tinytetris,80x23 terminal tetris game.
 chat,tgt,,https://github.com/FedericoBruzzone/tgt,A TUI for Telegram written in Rust.
 chat,tuisky,,https://github.com/sugyan/tuisky,TUI client for Bluesky.
+backup,duplicacy-cli-cron,https://github.com/GeiserX/duplicacy-cli-cron,https://github.com/GeiserX/duplicacy-cli-cron,"Docker-based encrypted dual-storage backup automation using Duplicacy CLI with cross-site redundancy."
+monitor,duplicacy-exporter,https://github.com/GeiserX/duplicacy-exporter,https://github.com/GeiserX/duplicacy-exporter,"Real-time Prometheus exporter for Duplicacy backups with live speed, progress, and completion metrics."


### PR DESCRIPTION
## Summary

- Adds [duplicacy-cli-cron](https://github.com/GeiserX/duplicacy-cli-cron) to the **Backup** category — Docker-based encrypted dual-storage backup automation using Duplicacy CLI with cross-site redundancy
- Adds [duplicacy-exporter](https://github.com/GeiserX/duplicacy-exporter) to the **System monitoring** category — Real-time Prometheus exporter for Duplicacy backups with live speed, progress, and completion metrics
