### PR TITLE
Add ePubLangMerger to conversion category

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2013,4 +2013,4 @@ chat,slack-term,,https://github.com/erroneousboat/slack-term,Slack client for th
 games,tinytetris,,https://github.com/taylorconor/tinytetris,80x23 terminal tetris game.
 chat,tgt,,https://github.com/FedericoBruzzone/tgt,A TUI for Telegram written in Rust.
 chat,tuisky,,https://github.com/sugyan/tuisky,TUI client for Bluesky.
-conversion,ePubLangMerger,https://github.com/GeiserX/ePubLangMerger,https://github.com/GeiserX/ePubLangMerger,"Merges two ePub files in different languages into a single bilingual ebook for parallel reading."
+conversion,ePubLangMerger,,https://github.com/GeiserX/ePubLangMerger,"Merges two ePub files in different languages into a single bilingual ebook for parallel reading."


### PR DESCRIPTION
Adds [ePubLangMerger](https://github.com/GeiserX/ePubLangMerger) — an R/Shiny web app that merges two ePub files in different languages into a single bilingual ebook for paragraph-level parallel reading. Available as a Docker container.