### PR TITLE
Add Resumx to productivity category

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2214,3 +2214,4 @@ backup,qbak,,https://github.com/andreas-glaser/qbak,A single-command backup help
 file-handling,CHMpy-sp,,https://github.com/AmmarSyamil/CHMpy,TUI made from Textual for changing file/folder permission in Linux. 
 text-search-replace,scooter,,https://github.com/thomasschafer/scooter,Interactive find-and-replace TUI app; By default the program recursively searches through files in the current directory and can also be used to process text from stdin.
 productivity,Sinkzone,,https://github.com/berbyte/sinkzone,"Application that blocks everything by default unless you explicitly allow it; A DNS tool for productivity, focus, and child safety."
+productivity,Resumx,https://resumx.dev,https://github.com/resumx/resumx,"Markdown resume renderer with auto page-fitting that outputs PDF, HTML, DOCX, and PNG."


### PR DESCRIPTION
Adds Resumx to the productivity category in `data/apps.csv`.

- **name**: Resumx
- **homepage**: https://resumx.dev
- **git**: https://github.com/resumx/resumx
- **description**: Markdown resume renderer with auto page-fitting that outputs PDF, HTML, DOCX, and PNG.