### PR TITLE
Add x402-proxy

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2227,3 +2227,4 @@ todo-manager,rusk,,https://github.com/tagirov/rusk,A minimal cross-platform term
 file-handling,doxx,,https://github.com/bgreenwell/doxx,"Terminal native document viewer for Word files (view, search and export documents)."
 online,IMDb Terminal Browser,,https://github.com/isene/IMDB,Ruby-based terminal application for discovering and managing movies and TV series from IMDb's Top lists.
 online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program allows you to manage and read content from various popular platforms without having to use a browser or separate apps.
+networking,x402-proxy,https://www.npmjs.com/package/x402-proxy,https://github.com/cascade-protocol/x402-proxy,"curl for x402 paid APIs. Auto-pays HTTP 402 responses with USDC on Base and Solana, with MCP proxy for AI agents."


### PR DESCRIPTION
Adds x402-proxy to the CLI apps database. `curl` for x402 paid APIs.

https://github.com/cascade-protocol/x402-proxy