### PR TITLE
Add greens

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2227,3 +2227,4 @@ todo-manager,rusk,,https://github.com/tagirov/rusk,A minimal cross-platform term
 file-handling,doxx,,https://github.com/bgreenwell/doxx,"Terminal native document viewer for Word files (view, search and export documents)."
 online,IMDb Terminal Browser,,https://github.com/isene/IMDB,Ruby-based terminal application for discovering and managing movies and TV series from IMDb's Top lists.
 online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program allows you to manage and read content from various popular platforms without having to use a browser or separate apps.
+git,greens,,https://github.com/yuvrajangadsingh/greens,Mirror work contributions (commits PRs reviews issues) from a private GitHub org to your personal profile without copying source code.


### PR DESCRIPTION
Adds greens to the git category.

greens is a bash CLI that mirrors work contributions (commits, PRs, reviews, issues) from a private GitHub org to your personal GitHub profile. No source code is copied, just contribution metadata. Runs via cron, set it up once and forget about it.

https://github.com/yuvrajangadsingh/greens