### PR TITLE
Add gh-star-history

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2227,3 +2227,4 @@ todo-manager,rusk,,https://github.com/tagirov/rusk,A minimal cross-platform term
 file-handling,doxx,,https://github.com/bgreenwell/doxx,"Terminal native document viewer for Word files (view, search and export documents)."
 online,IMDb Terminal Browser,,https://github.com/isene/IMDB,Ruby-based terminal application for discovering and managing movies and TV series from IMDb's Top lists.
 online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program allows you to manage and read content from various popular platforms without having to use a browser or separate apps.
+git,gh-star-history,,https://github.com/ykdojo/gh-star-history,Visualize and compare GitHub star history as interactive charts.


### PR DESCRIPTION
Added gh-star-history to the git category in data/apps.csv.

- **name:** gh-star-history
- **git:** https://github.com/ykdojo/gh-star-history
- **description:** Visualize and compare GitHub star history as interactive charts.