### PR TITLE
Add nless

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2064,6 +2064,7 @@ cheatsheet,gocheat,,https://github.com/Achno/gocheat,"Customizable TUI cheatshee
 productivity,hnjobs,,https://github.com/mwinters0/hnjobs,Console tool to find the best match on Who's Hiring.
 viewers,hygg,,https://github.com/kruserr/hygg,Minimalistic Vim-like TUI document reader.
 data-management-tabular,levite,,https://github.com/RauliL/levite,A TUI spreadsheet application that uses an RPN formulas and features a Vi-friendly interface.
+data-management-tabular,nless,,https://github.com/mpryor/nothing-less,"Terminal pager for exploring and analyzing tabular data with vi keybindings and automatic delimiter inference. Supports CSV, TSV, JSON, logs, and streaming stdin."
 productivity,multranslate,,https://github.com/Lifailon/multranslate,"A TUI for translating text in multiple translators simultaneously, with support for translation history and language detection."
 online,PagerDuty TUI,,https://github.com/Mk555/pagerduty-tui,Minimalistic terminal UI to manage triggered incidents.
 note-taking,pdiary,,https://github.com/manipuladordedados/pdiary,A simple terminal diary journal application written in Python with encryption support.


### PR DESCRIPTION
Adding [nless](https://github.com/mpryor/nothing-less) to the `data-management-tabular` category.

**nless** is a TUI pager for exploring and analyzing tabular data with vi keybindings. Pipe in anything — CSV, TSV, JSON, logs, streaming output — and nless infers the structure so you can filter, sort, pivot, and reshape without config. Built on Python/Textual.

- **Install**: `pip install nothing-less` or `brew install mpryor/tap/nless`
- **License**: MIT
- **Repo**: https://github.com/mpryor/nothing-less