### PR TITLE
Add faf-cli to AI category

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2227,3 +2227,4 @@ todo-manager,rusk,,https://github.com/tagirov/rusk,A minimal cross-platform term
 file-handling,doxx,,https://github.com/bgreenwell/doxx,"Terminal native document viewer for Word files (view, search and export documents)."
 online,IMDb Terminal Browser,,https://github.com/isene/IMDB,Ruby-based terminal application for discovering and managing movies and TV series from IMDb's Top lists.
 online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program allows you to manage and read content from various popular platforms without having to use a browser or separate apps.
+ai,faf-cli,https://faf.one,https://github.com/Wolfe-Jam/faf-cli,"IANA-registered AI context format CLI. Define your project once in .faf, sync to CLAUDE.md and AGENTS.md. Works with Claude, Gemini, Grok, any AI. Anthropic MCP #2759."

--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2229,3 +2229,4 @@ file-handling,doxx,,https://github.com/bgreenwell/doxx,"Terminal native document
 online,IMDb Terminal Browser,,https://github.com/isene/IMDB,Ruby-based terminal application for discovering and managing movies and TV series from IMDb's Top lists.
 online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program allows you to manage and read content from various popular platforms without having to use a browser or separate apps.
 cheatsheet,mdpick,,https://github.com/toolleeo/mdpick,"A terminal user interface (TUI) tool for interactively selecting and extracting code blocks or links from Markdown files and copy them to the clipboard, ready for being pasted right in the command line or anywhere else, or a tmux pane."
+ai,faf-cli,https://faf.one,https://github.com/Wolfe-Jam/faf-cli,"IANA-registered AI context format CLI. Define your project once in .faf, sync to CLAUDE.md and AGENTS.md. Works with Claude, Gemini, Grok, any AI. Anthropic MCP #2759."


### PR DESCRIPTION
## New App Submission

- **Name:** faf-cli
- **Homepage:** https://faf.one
- **Git:** https://github.com/Wolfe-Jam/faf-cli
- **Description:** IANA-registered AI context format CLI. Define your project once in .faf, sync to CLAUDE.md and AGENTS.md. Works with Claude, Gemini, Grok, any AI. Anthropic MCP #2759.

**Category:** ai

---

- IANA-registered MIME type: `application/vnd.faf+yaml`
- Merged into Anthropic MCP ecosystem ([#2759](https://github.com/modelcontextprotocol/servers/pull/2759))
- 36,000+ npm downloads across 16 packages
- MIT licensed
- npm: https://www.npmjs.com/package/faf-cli