### PR TITLE
Add brood-box

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2159,6 +2159,7 @@ time-tracker,Hammerclock,,https://github.com/itworks99/hammerclock,TUI chess clo
 ai,CarthageAI,,https://github.com/alaadotcom/CarthageAI,Multi-provider AI terminal assistant for developers and AI enthusiasts.
 data-management-json,Konfigo,,https://github.com/ebogdum/konfigo,"Command-line tool designed to work with multiple configuration file formats like JSON, YAML, TOML."
 ai,Browser CLI,,https://github.com/browsemake/browser-cli,AI agent browser automation tool.
+ai,brood-box,https://github.com/stacklok/brood-box,https://github.com/stacklok/brood-box,"Run coding agents (Claude Code, Codex, OpenCode) inside hardware-isolated microVMs with snapshot isolation, egress control, and MCP authorization."
 copilot,Smart-Shell,,https://github.com/Lusan-sapkota/smart-shell,Intelligent terminal assistant that converts natural language into executable Bash or Zsh commands using Gemini AI model via google-genai SDK.
 email,gmailtail,,https://github.com/c4pt0r/gmailtail,"Command-line tool to monitor Gmail messages and output the as JSON; The program in designed for automation, monitoring and integration with other tools."
 file-dir-cleanup,Duplito,,https://github.com/ftarlao/duplito,Command-line tool designed to help you identify duplicate file on your system by listing the files in folders like ls does and highlighting what is duplicate.


### PR DESCRIPTION
## Summary

Add [brood-box](https://github.com/stacklok/brood-box) to the `ai` category.

brood-box is a CLI tool for running coding agents (Claude Code, Codex, OpenCode) inside hardware-isolated microVMs. It provides snapshot isolation, egress control, and MCP authorization to keep your host system safe while agents work on your code.

## Entry added

```
ai,brood-box,https://github.com/stacklok/brood-box,https://github.com/stacklok/brood-box,"Run coding agents (Claude Code, Codex, OpenCode) inside hardware-isolated microVMs with snapshot isolation, egress control, and MCP authorization."
```

🤖 Generated with [Claude Code](https://claude.ai/code) and [Brood Box](https://github.com/stacklok/brood-box)