### PR TITLE
Add notion-cli

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2227,3 +2227,4 @@ todo-manager,rusk,,https://github.com/tagirov/rusk,A minimal cross-platform term
 file-handling,doxx,,https://github.com/bgreenwell/doxx,"Terminal native document viewer for Word files (view, search and export documents)."
 online,IMDb Terminal Browser,,https://github.com/isene/IMDB,Ruby-based terminal application for discovering and managing movies and TV series from IMDb's Top lists.
 online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program allows you to manage and read content from various popular platforms without having to use a browser or separate apps.
+note-taking,notion-cli,,https://github.com/andrzejchm/notion-cli,"A terminal-based CLI for reading, writing, and managing Notion pages and databases, with support for Markdown rendering, database querying, and AI agent workflows."


### PR DESCRIPTION
Adds notion-cli to the note-taking category.

TypeScript CLI for Notion. Reads pages as Markdown, queries databases with filters, creates and edits pages, manages comments. Has multi-profile auth (OAuth + integration tokens). Works well as a tool for AI coding agents too.