### PR TITLE
Add gitty — single-binary Git+GitHub CLI

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2227,3 +2227,4 @@ todo-manager,rusk,,https://github.com/tagirov/rusk,A minimal cross-platform term
 file-handling,doxx,,https://github.com/bgreenwell/doxx,"Terminal native document viewer for Word files (view, search and export documents)."
 online,IMDb Terminal Browser,,https://github.com/isene/IMDB,Ruby-based terminal application for discovering and managing movies and TV series from IMDb's Top lists.
 online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program allows you to manage and read content from various popular platforms without having to use a browser or separate apps.
+git,gitty,https://github.com/Omibranch/gitty,https://github.com/Omibranch/gitty,"Single-binary Git+GitHub CLI. Replaces git add / git commit / git push with one command: gitty up. Supports selective line commits, interactive conflict resolution, and alias chaining."


### PR DESCRIPTION
## gitty

[gitty](https://github.com/Omibranch/gitty) is a single Go binary (~6 MB, zero dependencies) that wraps Git and GitHub into short, human-readable commands.

**Core command:** \`gitty up\` replaces \`git add + git commit + git push\` in one command.

### Added entry
\`\`\`
git,gitty,https://github.com/Omibranch/gitty,https://github.com/Omibranch/gitty,"Single-binary Git+GitHub CLI..."
\`\`\`

Features: selective line commits, interactive conflict resolution, full history rewriting, aliases, proxy support.
MIT · Go · v2.2.0