### PR TITLE
Add clipgate to copy-paste category

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2201,6 +2201,7 @@ programming,PAR MCP Inspector TUI,,https://github.com/paulrobello/par-mcp-inspec
 chat,ZUSE,,https://github.com/babycommando/zuse,Minimal IRC client for the terminal written in Go with Bubbletea.
 transfer,Filebin cli,,https://github.com/mshirazkamran/filebin-api,CLI tool to share files temporarily from the terminal (share short code to download on the other machine).
 screen-recorder,rewindtty,,https://github.com/debba/rewindtty,A terminal session recorder and replayer written in C that allows you to capture and replay terminal sessions with precise timing.
+copy-paste,clipgate,https://clipgate.github.io,https://github.com/clipgate/clip-gate,Terminal-native clipboard vault that auto-classifies copies into types (secrets, code, URLs, errors, JSON, shell commands) and flags secrets in real time. Local-first Vault store. No cloud, no account, no telemetry.
 copy-paste,clipboard-viewer,,https://github.com/jaggzh/xclipview-tui,Terminal-based clipboard browser.
 utility,loopctl,,https://github.com/Karvy-Singh/loopctl,The program allows you to repeat a media/section of media x number of times and to repeat a certain part of media.
 ai-cli-commands,Ollamacode CLI,,https://github.com/tooyipjee/ollamacode,The program creates a Python script from natural language and execute it automatically.


### PR DESCRIPTION
Adds ClipGate to the `copy-paste` category.

- **Homepage:** https://clipgate.github.io
- **Repo:** https://github.com/clipgate/clip-gate
- **Language:** Rust (single 4.6 MB statically linked binary)
- **Platforms:** macOS, Linux, Windows

**What it does**

ClipGate is a local-first, terminal-native clipboard manager that classifies every copied item by shape — command, error, path, URL, JSON, diff, or secret — and makes retrieval semantic ("last error", "last path") instead of a chronological scroll hunt. Secret-shaped values (tokens, API keys, private keys, JWTs) are quarantined into a separate vault so they never sit in the default paste history.

**Why it fits `copy-paste`**

Core feature set is clipboard capture, classification, retrieval, and vault management from the shell. No cloud, no account, no telemetry. Complements existing entries (yank, shcopy, clipsync) but targets the developer workflow explicitly.

Let me know if you'd like the description shortened or the fields ordered differently.