### PR TITLE
Add grugbot420 to AI category

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2227,3 +2227,4 @@ todo-manager,rusk,,https://github.com/tagirov/rusk,A minimal cross-platform term
 file-handling,doxx,,https://github.com/bgreenwell/doxx,"Terminal native document viewer for Word files (view, search and export documents)."
 online,IMDb Terminal Browser,,https://github.com/isene/IMDB,Ruby-based terminal application for discovering and managing movies and TV series from IMDb's Top lists.
 online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program allows you to manage and read content from various popular platforms without having to use a browser or separate apps.
+ai,grugbot420,,https://github.com/grug-group420/grugbot420,AI-powered CLI assistant with neuromorphic intelligence. Zero dependencies built purely with Bun.


### PR DESCRIPTION
Adding [grugbot420](https://github.com/grug-group420/grugbot420) to the AI / ChatGPT category.

## About grugbot420

An AI-powered CLI assistant built with Bun.js. Zero dependencies.

### Features
- Neuromorphic intelligence engine
- 'Grug Brain Developer' philosophy
- Server mode with HTTP API
- Pipeline-native shell integration