### PR TITLE
Add morning-brief (AI / ChatGPT)

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2227,3 +2227,4 @@ todo-manager,rusk,,https://github.com/tagirov/rusk,A minimal cross-platform term
 file-handling,doxx,,https://github.com/bgreenwell/doxx,"Terminal native document viewer for Word files (view, search and export documents)."
 online,IMDb Terminal Browser,,https://github.com/isene/IMDB,Ruby-based terminal application for discovering and managing movies and TV series from IMDb's Top lists.
 online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program allows you to manage and read content from various popular platforms without having to use a browser or separate apps.
+ai,morning-brief,https://www.npmjs.com/package/morning-brief,https://github.com/Fisher521/morning-brief,"BYOK CLI that pulls open GitHub PRs/issues, your reading queue (Readwise/RSS/URL file/Burn) and local tasks, and uses Claude to synthesize a daily morning brief in markdown."


### PR DESCRIPTION
Hi — adding a new entry to the `AI / ChatGPT` section.

**morning-brief** — a BYOK CLI that pulls open GitHub PRs/issues, your reading queue (supports Readwise, RSS feeds, plain URL text files, and Burn) and local tasks, then uses Claude to synthesize a short daily morning brief in markdown. Useful for indie hackers / solo devs who want one file that tells them what to focus on before they open GitHub/their bookmarks/etc.

- Repo: https://github.com/Fisher521/morning-brief
- npm: https://www.npmjs.com/package/morning-brief
- License: MIT
- Node 18+
- Source adapters are pluggable; no vendor lock-in

Change is a single-line addition to `data/apps.csv` only, per the contribution guidelines.