### PR TITLE
Add reading-filter and digest-or-burn (AI reading tools)

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2227,3 +2227,5 @@ todo-manager,rusk,,https://github.com/tagirov/rusk,A minimal cross-platform term
 file-handling,doxx,,https://github.com/bgreenwell/doxx,"Terminal native document viewer for Word files (view, search and export documents)."
 online,IMDb Terminal Browser,,https://github.com/isene/IMDB,Ruby-based terminal application for discovering and managing movies and TV series from IMDb's Top lists.
 online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program allows you to manage and read content from various popular platforms without having to use a browser or separate apps.
+ai,reading-filter,,https://github.com/Fisher521/reading-filter,AI tells you what to read first. Scores bookmarks by relevance novelty and actionability.
+ai,digest-or-burn,,https://github.com/Fisher521/digest-or-burn,Burn-pile CLI for markdown hoards. Triage files into absorb act or burn.


### PR DESCRIPTION
## Summary

Adds two AI-powered reading/triage CLI tools to the **AI / ChatGPT** category:

- **reading-filter** — Scores bookmarks by relevance, novelty, and actionability so you read what matters first.
- **digest-or-burn** — Burn-pile CLI for markdown hoards. Triage files into absorb, act, or burn.

Both are lightweight Node.js CLIs installable via npm.