### PR TITLE
Add agent-shadow-brain to AI category

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2227,3 +2227,4 @@ todo-manager,rusk,,https://github.com/tagirov/rusk,A minimal cross-platform term
 file-handling,doxx,,https://github.com/bgreenwell/doxx,"Terminal native document viewer for Word files (view, search and export documents)."
 online,IMDb Terminal Browser,,https://github.com/isene/IMDB,Ruby-based terminal application for discovering and managing movies and TV series from IMDb's Top lists.
 online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program allows you to manage and read content from various popular platforms without having to use a browser or separate apps.
+ai,agent-shadow-brain,,https://github.com/theihtisham/agent-shadow-brain,"A background AI agent that continuously monitors your codebase, detects drift from design intent, catches cross-file issues, and surfaces real-time feedback without interrupting your workflow."


### PR DESCRIPTION
## Summary

Adds `agent-shadow-brain` to the `ai` category in `data/apps.csv`.

**agent-shadow-brain** is a background AI agent that continuously monitors your codebase, detects drift from design intent, catches cross-file issues, and surfaces real-time feedback without interrupting your workflow.

- **Category:** ai
- **Repository:** https://github.com/theihtisham/agent-shadow-brain