### PR TITLE
added Shiplog in the Data Management Section (shiplog.page)

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,7 @@ Tools to manage data files.
 
 * [chndlr](https://github.com/bharatvaj/chndlr) - Replacement for xdg-open; It determines the appropriate application to open a file or URL based on user-defined rules in configuration.
 * [crudini](https://github.com/pixelb/crudini) - A utility for manipulating .ini files.
+* [Shiplog](https://shiplog.page) - A tool to push changelog entries to your own public page via CLI (yourapp.shiplog.page)
 * [datadash](https://github.com/keithknott26/datadash) - Visualize and graph data in the terminal.
 * [datasetGPT](https://github.com/radi-cho/datasetGPT) - A command-line interface and a Python library for inferencing Large Language Models to generate textual datasets.
 * [dateutils](http://www.fresse.org/dateutils/) - Dateutils are a bunch of tools that revolve around fiddling with dates and times in the command line with a strong focus on use cases that arise when dealing with large amounts of financial data.


### PR DESCRIPTION
I proposed to add a tool called Shiplog (https://shiplog.page) that allows creators and developers to organise and host their product's updates on their own polished changelog public page (yourapp.shiplog.page). They can add entries via UI Dashboard, AI (by entering rough notes) or CLI directly from the project's terminal. The entire setup takes less than 60 seconds. Free 7-day trial, then 4.99$/mo. Example page: https://calcifyai.shiplog.page