### PR TITLE
Add grug-cli to programming category

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2198,6 +2198,7 @@ editors,Erys,,https://github.com/natibek/erys,Terminal Interface for Jupyter Not
 online,flashback,,https://github.com/cachebag/flashback,Find old YouTube content that the algorithm hides by searching videos from specific years.
 online,YouTube TUI,,https://github.com/Siriusmart/youtube-tui/tree/master,An aesthetically pleasing YouTube TUI written in Rust.
 programming,PAR MCP Inspector TUI,,https://github.com/paulrobello/par-mcp-inspector-tui,TUI to inspect and test MCP (model context protocol) servers.
+programming,grug-cli,,https://github.com/grug-group420/grug-cli,"Zero-dependency developer toolkit written for Bun.js — line counts, directory size, TODO/FIXME scanning, and a bench subcommand for quick repo profiling."
 chat,ZUSE,,https://github.com/babycommando/zuse,Minimal IRC client for the terminal written in Go with Bubbletea.
 transfer,Filebin cli,,https://github.com/mshirazkamran/filebin-api,CLI tool to share files temporarily from the terminal (share short code to download on the other machine).
 screen-recorder,rewindtty,,https://github.com/debba/rewindtty,A terminal session recorder and replayer written in C that allows you to capture and replay terminal sessions with precise timing.


### PR DESCRIPTION
Adds **grug-cli**, a zero-dependency developer toolkit written for Bun.js.

- Repo: https://github.com/grug-group420/grug-cli
- License: MIT
- Features: line counting, directory size reporting, TODO/FIXME scanning, and a `bench` subcommand for quick repo profiling
- Single CSV row added under the `programming` category, per CONTRIBUTING guidelines. Makefile-generated files (`cli-apps.md`, `README.md`) intentionally left untouched for the maintainer to regenerate.