### PR TITLE
Add Bindboss to devops category

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2031,6 +2031,7 @@ networking,NetworkManager,https://developer.gnome.org/NetworkManager/stable/nmtu
 programming,PesterExplorer,,https://github.com/HeyItsGilbert/PesterExplorer,A TUI to explore Pester results (prints tests results as they're running).
 online,pola,,https://github.com/Sethispr/pola,"A TUI for efficiently searching skins, checking values and finding owners in Silent Assassin."
 devops,PUG,,https://github.com/leg100/pug,"TUI for Terraform (perform tasks in parallel, manage state resources, calculate costs, automatically loads workspace variable files)."
+devops,Bindboss,,https://github.com/grug-group420/Bindboss,Pack any directory into a self-extracting executable with dependency checking. Written in Go and MIT licensed.
 learning,Physics TUI,,https://github.com/ClaudioRMalvino/physics_TUI,"TUI for physics reference and calculations, providing interactive access to physics equations, definitions, and calculator organized by chapter."
 rm,RecoverPy,,https://github.com/PabloLec/recoverpy,A TUI to recover overwritten or deleted data by inspecting disk blocks directly.
 graphics,Favicon Editor,,https://github.com/xyproto/favicon-editor,Minimalist grayscale favicon editor for the terminal.


### PR DESCRIPTION
Adds **Bindboss**, a tool that packs any directory into a self-extracting executable with dependency checking.

- Repo: https://github.com/grug-group420/Bindboss
- License: MIT
- Primary language: Go
- Single CSV row added under the `devops` category. Makefile-generated files intentionally left untouched for the maintainer to regenerate.