### PR TITLE
Add linear-cli

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2228,3 +2228,4 @@ file-handling,doxx,,https://github.com/bgreenwell/doxx,"Terminal native document
 online,IMDb Terminal Browser,,https://github.com/isene/IMDB,Ruby-based terminal application for discovering and managing movies and TV series from IMDb's Top lists.
 online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program allows you to manage and read content from various popular platforms without having to use a browser or separate apps.
 cheatsheet,mdpick,,https://github.com/toolleeo/mdpick,"A terminal user interface (TUI) tool for interactively selecting and extracting code blocks or links from Markdown files and copy them to the clipboard, ready for being pasted right in the command line or anywhere else, or a tmux pane."
+productivity,linear-cli,https://github.com/phnx-labs/linear-cli,https://github.com/phnx-labs/linear-cli,Zero-dependency Python CLI for Linear issue tracking; works as a Claude Code skill and supports human and AI agent workflows.


### PR DESCRIPTION
## What

Adds [linear-cli](https://github.com/phnx-labs/linear-cli) to the `productivity` category.

## Why

linear-cli is a single-file, zero-dependency Python CLI for Linear issue tracking. It requires no third-party packages (stdlib only), is MIT licensed, and installs via a single curl command. It also ships with a SKILL.md so AI coding agents (Claude Code, Codex, Gemini, Cursor) can use it as a skill.

- Homepage/repo: https://github.com/phnx-labs/linear-cli
- Category: productivity
- License: MIT
- Install: `curl -sSL https://raw.githubusercontent.com/phnx-labs/linear-cli/main/install.sh | bash`