### PR TITLE
Add agenttrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ Some links are available to [related resources](#resources).
 
 Summary:
 
-* Apps/tools: **2229**
+* Apps/tools: **2230**
 * Categories: **81**
 
 # Contents
 
-* [AI / ChatGPT](#ai) (47), [AI terminal command generator](#ai-cli-commands) (16), [Animation](#animation) (39), [Anki, decks and flashcards](#flashcard) (10)
+* [AI / ChatGPT](#ai) (48), [AI terminal command generator](#ai-cli-commands) (16), [Animation](#animation) (39), [Anki, decks and flashcards](#flashcard) (10)
 * [Backup](#backup) (20)
 * [Calculators](#calc) (21), [Chat and instant messaging](#chat) (52), [Clean up of files and directories](#file-dir-cleanup) (17), [Co-pilot](#copilot) (12), [Command launchers](#launcher) (28), [Commands cheatsheet and snippets](#cheatsheet) (34), [Containerization and virtualization](#vm) (25), [Conversion](#conversion) (17), [Copy/paste and clipboard](#copy-paste) (11)
 * [Data management](#data-management) (18), [Data management - JSON/YAML/etc.](#data-management-json) (48), [Data management - Tabular data](#data-management-tabular) (37), [Data transfer](#transfer) (47), [DevOps](#devops) (22), [Diff](#diff) (12), [Directory changers (alternatives to cd)](#cd) (23), [Disk usage analyzers](#disk-analyzer) (14)
@@ -39,6 +39,7 @@ Summary:
 
 Interfaces and front-ends to GPT engines and other tools powered by artificial intelligence and Natural Language Processing.
 
+* [agenttrace](https://luoyuctl.github.io/agenttrace/) - Local-first TUI observability for AI coding agent sessions, showing cost, tokens, tool failures, latency, anomalies, health scores, diffs, and CI gates.
 * [AI](https://github.com/nitefood/ai-bash-gpt) - A command-line ChatGPT client in BASH with conversation/completion support.
 * [AIChat](https://github.com/sigoden/aichat) - Using ChatGPT/GPT-3.5/GPT-4 in the terminal.
 * [Alibaba-CLI-Scraper](https://github.com/poneoneo/Alibaba-CLI-Scraper) - Create your own Alibaba dataset and interact with it in plain English.

--- a/data/apps.csv
+++ b/data/apps.csv
@@ -823,6 +823,7 @@ email,Himalaya,,https://github.com/soywod/himalaya,Command-line interface for em
 todo-manager,Dooit,,https://github.com/kraanzu/dooit,"Todo manager with interactive and beautiful UI, and vim keybindings."
 copilot,Commandpilot,,https://github.com/barthr/commandpilot,An assistant which uses ChatGPT to aid in constructing commands for bash.
 ai,AI,,https://github.com/nitefood/ai-bash-gpt,A command-line ChatGPT client in BASH with conversation/completion support.
+ai,agenttrace,https://luoyuctl.github.io/agenttrace/,https://github.com/luoyuctl/agenttrace,"Local-first TUI observability for AI coding agent sessions, showing cost, tokens, tool failures, latency, anomalies, health scores, diffs, and CI gates."
 security,feroxbuster,,https://github.com/epi052/feroxbuster,"A fast, simple, recursive content discovery tool written in Rust."
 text-search,ugrep,,https://github.com/Genivia/ugrep,"Ultra fast grep with interactive TUI, fuzzy search, boolean queries, hexdumps and more."
 music,BadaBoomBooks,,https://github.com/WirlyWirly/BadaBoomBooks,Quickly organize audiobooks using a terminal and web-browser.


### PR DESCRIPTION
Adds agenttrace to the AI / ChatGPT category.

agenttrace is a local-first TUI for observing AI coding agent sessions. It parses local Claude Code, Codex CLI, Gemini CLI, Aider, Cursor export, Hermes, OpenCode, Kimi, and Copilot-style logs and surfaces cost, token usage, tool failures, latency, anomalies, health scores, diffs, and CI gates.

Repository: https://github.com/luoyuctl/agenttrace