### PR TITLE
Add agenttrace

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -1904,6 +1904,7 @@ monitor,WTF,,https://github.com/senorprogrammer/wtf,The personal information das
 viewers,Yozefu,,https://github.com/MAIF/yozefu,An TUI for exploring data of a Kafka cluster.
 monitor,act3,,https://github.com/dhth/act3,Glance at the last 3 runs of your Github Actions.
 monitor,amtui,,https://github.com/pehlicd/amtui/,"A terminal-based user interface (TUI) application that allows you to interact with Prometheus Alertmanager using your terminal. It provides a convenient way to monitor alerts, view silences, and check the status of Alertmanager instances."
+monitor,agenttrace,https://github.com/luoyuctl/agenttrace,https://github.com/luoyuctl/agenttrace,"Local-first TUI for AI coding-agent session logs, covering cost, tokens, latency, tool failures, diffs, reports, and CI gates."
 monitor,austin-tui,,https://github.com/P403n1x87/austin-tui,The top-like TUI user interface for Austin.
 programming,blinkenlights,,https://github.com/jart/blink,TUI that may be used for debugging x86_64-linux or i8086 programs across platforms.
 file-handling,burf,,https://github.com/razeghi71/burf,TUI for Google Cloud Storage (GCS).


### PR DESCRIPTION
Adds agenttrace to data/apps.csv as a monitor entry for AI coding agent observability.

Validation:
- Parsed data/apps.csv with Python csv.DictReader
- Ran git diff --check