### PR TITLE
Add codex-profiles

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2228,3 +2228,4 @@ file-handling,doxx,,https://github.com/bgreenwell/doxx,"Terminal native document
 online,IMDb Terminal Browser,,https://github.com/isene/IMDB,Ruby-based terminal application for discovering and managing movies and TV series from IMDb's Top lists.
 online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program allows you to manage and read content from various popular platforms without having to use a browser or separate apps.
 cheatsheet,mdpick,,https://github.com/toolleeo/mdpick,"A terminal user interface (TUI) tool for interactively selecting and extracting code blocks or links from Markdown files and copy them to the clipboard, ready for being pasted right in the command line or anywhere else, or a tmux pane."
+ai,codex-profiles,https://github.com/Ducksss/codex-profiles,https://github.com/Ducksss/codex-profiles.git,"Bash CLI helper that launches Codex CLI/Desktop with isolated CODEX_HOME profiles for safe multi-account switching."


### PR DESCRIPTION
## Summary

Adds `codex-profiles`, a small open-source helper for switching Codex CLI and Codex Desktop accounts with isolated `CODEX_HOME` profiles.

## Why

This fits the CLI catalogue as a Bash command-line helper for Codex users who need safe multi-account switching.

## Validation

- Ran `git diff --check`
- Parsed `data/apps.csv` with Ruby CSV
