### PR TITLE
Add linkedin2md: LinkedIn data exports to Markdown conversion tool

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -1915,6 +1915,7 @@ ai,hns,,https://github.com/primaprashant/hns,"A privacy-focused open-source comm
 git,ggc,,https://github.com/bmf-san/ggc,A modern Git CLI tool with both traditional command-line and interactive incremental-search UI.
 transfer,Better Curl Saul,,https://github.com/DeprecatedLuar/better-curl-saul,HTTP client with persistent workspace configs and dynamic variables to eliminate API setup repetition.
 conversion,lx,,https://github.com/rasros/lx,Convert arbitrary files into Markdown-fenced blocks for LLM context.
+conversion,linkedin2md,,https://github.com/juanmanueldaza/linkedin2md,"Convert LinkedIn data exports to Markdown for LLM analysis and PDF resume generation."
 monitor,Cloud Code Usage Monitor,,https://github.com/Maciek-roboblog/Claude-Code-Usage-Monitor,Real-time Claude Code usage monitor with predictions and warnings.
 text-search,Csope,,https://github.com/agvxov/csope,"C source code browser - Fork of Cscope version 15,9, with various improvements."
 networking,CuTE,,https://github.com/PThorpe92/CuTE,"TUI to help build, execute and save curl commands, recursively download from remote sources, test your API endpoints, and mange your keys."


### PR DESCRIPTION
## linkedin2md

A zero-dependency Python CLI that converts LinkedIn ZIP data exports into clean, structured Markdown files for LLM analysis and PDF resume generation.

- **Category**: Conversion (data format converter)
- **GitHub**: https://github.com/juanmanueldaza/linkedin2md
- **PyPI**: https://pypi.org/project/linkedin2md/

Added entry to `data/apps.csv` under the "conversion" category. The README was regenerated using the project's Makefile.

```bash
pip install linkedin2md
linkedin2md /path/to/linkedin_export.zip
```