### PR TITLE
Add appbun

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2110,6 +2110,7 @@ games,word-blazer,,https://github.com/mmed-hajnasr/word-blazer,TUI labyrinth gam
 writing,sdcv,,https://github.com/Dushistov/sdcv,"Simple, cross-platform, text-based utility for working with dictionaries in StarDict format."
 learning,Countryfetch,,https://github.com/nik-rev/countryfetch,A Command-line tool similar to Neofetch for obtaining information about your country.
 utility,gust,,https://github.com/josephburgess/gust,Command line weather app written in Go.
+programming-boilerplate,appbun,https://www.npmjs.com/package/appbun,https://github.com/bigmacfive/appbun,Generate inspectable Electrobun desktop app projects from URLs with metadata icon discovery and installer-friendly packaging flows.
 monitor-top,vitals,,https://github.com/AngelJumbo/vitals,System usage visualizer and top replacement for Linux.
 ai,Ferrules,,https://github.com/aminediro/ferrules,"Modern, fast, document parser written in Rust designed to generate LLM-ready documents."
 games,Bashtaker,,https://github.com/EC2854/bashtaker,Demake of Helltaker (videogame) written in bash.


### PR DESCRIPTION
Adds appbun to data/apps.csv under program templates and boilerplate.

appbun is a CLI for generating inspectable Electrobun desktop app projects from URLs, including metadata icon discovery and installer-friendly packaging flows.