### PR TITLE
Add hcom to copilot category

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2160,6 +2160,7 @@ ai,CarthageAI,,https://github.com/alaadotcom/CarthageAI,Multi-provider AI termin
 data-management-json,Konfigo,,https://github.com/ebogdum/konfigo,"Command-line tool designed to work with multiple configuration file formats like JSON, YAML, TOML."
 ai,Browser CLI,,https://github.com/browsemake/browser-cli,AI agent browser automation tool.
 copilot,Smart-Shell,,https://github.com/Lusan-sapkota/smart-shell,Intelligent terminal assistant that converts natural language into executable Bash or Zsh commands using Gemini AI model via google-genai SDK.
+copilot,hcom,https://github.com/aannoo/hcom,https://github.com/aannoo/hcom.git,"CLI for messaging, watching, and spawning coding agents across terminals. Supports Claude Code, Gemini CLI, Codex, OpenCode, Kilo Code, Antigravity, and Cursor."
 email,gmailtail,,https://github.com/c4pt0r/gmailtail,"Command-line tool to monitor Gmail messages and output the as JSON; The program in designed for automation, monitoring and integration with other tools."
 file-dir-cleanup,Duplito,,https://github.com/ftarlao/duplito,Command-line tool designed to help you identify duplicate file on your system by listing the files in folders like ls does and highlighting what is duplicate.
 animation,cellscape,,https://github.com/ashish0kumar/cellscape,TUI simulator for eight classic cellular automata.


### PR DESCRIPTION
Adds `hcom` to `data/apps.csv` under the `copilot` category.

`hcom` is a CLI for messaging, watching, and spawning coding agents across terminals. It integrates with Claude Code, Gemini CLI, Codex, OpenCode, Kilo Code, Antigravity, and Cursor.

Validation:
- Edited `data/apps.csv` only; left the generated README untouched.
- Parsed the CSV successfully and confirmed all rows have five fields.
- Ran `git diff --check`.