### PR TITLE
Add slopless

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2228,3 +2228,4 @@ file-handling,doxx,,https://github.com/bgreenwell/doxx,"Terminal native document
 online,IMDb Terminal Browser,,https://github.com/isene/IMDB,Ruby-based terminal application for discovering and managing movies and TV series from IMDb's Top lists.
 online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program allows you to manage and read content from various popular platforms without having to use a browser or separate apps.
 cheatsheet,mdpick,,https://github.com/toolleeo/mdpick,"A terminal user interface (TUI) tool for interactively selecting and extracting code blocks or links from Markdown files and copy them to the clipboard, ready for being pasted right in the command line or anywhere else, or a tmux pane."
+writing,slopless,https://www.npmjs.com/package/slopless,https://github.com/seochecks-ai/slopless,Deterministic linter that flags AI-generated and padded prose in Markdown.


### PR DESCRIPTION
Adds slopless to the Writing category. slopless is a deterministic command-line linter and textlint preset that flags AI-generated and padded prose in Markdown without calling an LLM, so results are reproducible and usable in CI. It fits alongside existing prose linters in the list such as alex and write good.

Repo: https://github.com/seochecks-ai/slopless
npm: https://www.npmjs.com/package/slopless (MIT)