### PR TITLE
Fix UTF-8 handling in cli2md

### DIFF
--- a/cli2md.py
+++ b/cli2md.py
@@ -1,5 +1,9 @@
 import csv
+import sys
 import string
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding='utf-8')
 
 
 summary_template = """
@@ -23,7 +27,7 @@ A list of some online resources that contribute interesting links to apps and in
 
 
 def load_csv(file_name):
-    with open(file_name, 'r') as infile:
+    with open(file_name, 'r', encoding='utf-8') as infile:
         csv_reader = csv.DictReader(infile, delimiter=',')
         fields = csv_reader.fieldnames
         data = []


### PR DESCRIPTION
﻿## Summary

This updates `cli2md.py` to handle UTF-8 data consistently on Windows and other non-UTF-8 default environments.

## What changed

- Read CSV files with `encoding='utf-8'`.
- Reconfigure `stdout` to UTF-8 when supported, so generated Markdown can include Unicode characters when redirected to a file.

## Why

On Windows systems where Python defaults to a legacy code page such as GBK, running `python cli2md.py` can fail while reading CSV data or while writing Unicode Markdown output. The repository data is UTF-8, so making the encoding explicit keeps the generator portable.

## Validation

Tested on Windows with the default environment:

```powershell
python cli2md.py > $env:TEMP\awesome-cli-cli2md-output.md
```

The command completed successfully and produced Markdown output.
