### PR TITLE
Add tea-dash (git category)

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -1351,6 +1351,7 @@ package-manager,eget,,https://github.com/zyedidia/eget,Easily install prebuilt b
 versioning,fnc,https://fnc.bsdbox.org/index,,Interactive text-based user interface for Fossil.
 font,fnt,,https://github.com/alexmyczko/fnt,"apt for fonts, the missing font manager for macOS/Linux."
 git,gh-dash,,https://github.com/dlvhdr/gh-dash,A beautiful CLI dashboard for GitHub.
+git,tea-dash,,https://github.com/gbarany/tea-dash,A gh-dash-style terminal dashboard for Gitea and Forgejo.
 git,git-cc,,https://github.com/SKalt/git-cc,A git extension to help write conventional commits.
 monitor-top,gotop,,https://github.com/xxxserxxx/gotop,A terminal based graphical activity monitor inspired by gtop and vtop.
 security,gpg-tui,,https://github.com/orhun/gpg-tui,Manage your GnuPG keys with ease!


### PR DESCRIPTION
Adds a row to `data/apps.csv` (git category, next to gh-dash):

- **name**: tea-dash
- **homepage**: —
- **git**: https://github.com/gbarany/tea-dash
- **description**: A gh-dash-style terminal dashboard for Gitea and Forgejo.

It's a keyboard-driven TUI for PRs, issues, notifications, Actions runs, and local branches across Gitea/Forgejo instances. MIT, Go. Only the CSV is edited, per the contribution instructions.