### PR TITLE
Add iris

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2229,3 +2229,4 @@ file-handling,doxx,,https://github.com/bgreenwell/doxx,"Terminal native document
 online,IMDb Terminal Browser,,https://github.com/isene/IMDB,Ruby-based terminal application for discovering and managing movies and TV series from IMDb's Top lists.
 online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program allows you to manage and read content from various popular platforms without having to use a browser or separate apps.
 cheatsheet,mdpick,,https://github.com/toolleeo/mdpick,"A terminal user interface (TUI) tool for interactively selecting and extracting code blocks or links from Markdown files and copy them to the clipboard, ready for being pasted right in the command line or anywhere else, or a tmux pane."
+ai,iris,,https://github.com/itzenata/iris-tui,"Live TUI supervisor for every active Claude Code session: status, tokens, estimated cost, and one-pane approval of pending tool calls."


### PR DESCRIPTION
Adds [iris](https://github.com/itzenata/iris-tui) to the `ai` category — a live supervisor TUI for every active Claude Code session: per-session status, model, tokens, estimated cost, live activity feed, and one-pane approval of pending tool calls. Rust + ratatui, MIT, on crates.io as [iris-tui](https://crates.io/crates/iris-tui).

Edited `data/apps.csv` only, per the contribution instructions.