### PR TITLE
Add natocr

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2229,3 +2229,4 @@ file-handling,doxx,,https://github.com/bgreenwell/doxx,"Terminal native document
 online,IMDb Terminal Browser,,https://github.com/isene/IMDB,Ruby-based terminal application for discovering and managing movies and TV series from IMDb's Top lists.
 online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program allows you to manage and read content from various popular platforms without having to use a browser or separate apps.
 cheatsheet,mdpick,,https://github.com/toolleeo/mdpick,"A terminal user interface (TUI) tool for interactively selecting and extracting code blocks or links from Markdown files and copy them to the clipboard, ready for being pasted right in the command line or anywhere else, or a tmux pane."
+graphics,natocr,,https://github.com/alfredchiesa/natocr,"Native macOS Vision and Windows Runtime OCR from Python, with CLI output to text, table, JSON, hOCR, and searchable PDF."


### PR DESCRIPTION
Adds natocr to the graphics category in data/apps.csv.

natocr brings the OCR engines built into macOS (Vision framework) and Windows (Windows Runtime OCR) to the command line: `natocr scan.png` prints the recognized text, and `-f` switches output between plain text, a per-line table with confidence values, JSON, hOCR, and searchable PDF. Installs with `pip install 'natocr[cli]'`.

Note: the file was missing a trailing newline, so the diff also shows the previous last line - no content changed there.