### PR TITLE
Add gha (gh-actions-cli) to devops

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2229,3 +2229,4 @@ file-handling,doxx,,https://github.com/bgreenwell/doxx,"Terminal native document
 online,IMDb Terminal Browser,,https://github.com/isene/IMDB,Ruby-based terminal application for discovering and managing movies and TV series from IMDb's Top lists.
 online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program allows you to manage and read content from various popular platforms without having to use a browser or separate apps.
 cheatsheet,mdpick,,https://github.com/toolleeo/mdpick,"A terminal user interface (TUI) tool for interactively selecting and extracting code blocks or links from Markdown files and copy them to the clipboard, ready for being pasted right in the command line or anywhere else, or a tmux pane."
+devops,gha,,https://github.com/wille/gh-actions-cli,"Pin GitHub Actions to commit SHAs, enforce allowed-actions policies, and update them safely."


### PR DESCRIPTION
Adds [gha](https://github.com/wille/gh-actions-cli) to the `devops` category — a Go CLI that pins GitHub Actions to commit SHAs, enforces allowed-actions allowlist policies, and safely updates pinned actions. Edited `data/apps.csv` only, per the contribution instructions.