### PR TITLE
Add CodeAlmanac

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2229,3 +2229,4 @@ file-handling,doxx,,https://github.com/bgreenwell/doxx,"Terminal native document
 online,IMDb Terminal Browser,,https://github.com/isene/IMDB,Ruby-based terminal application for discovering and managing movies and TV series from IMDb's Top lists.
 online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program allows you to manage and read content from various popular platforms without having to use a browser or separate apps.
 cheatsheet,mdpick,,https://github.com/toolleeo/mdpick,"A terminal user interface (TUI) tool for interactively selecting and extracting code blocks or links from Markdown files and copy them to the clipboard, ready for being pasted right in the command line or anywhere else, or a tmux pane."
+ai,CodeAlmanac,,https://github.com/AlmanacCode/codealmanac,"Self-updating repo wiki for AI coding agents."


### PR DESCRIPTION
Adds CodeAlmanac to `data/apps.csv`.

Per the contribution instructions, this PR edits only the CSV source data and does not regenerate `README.md`.

Fields:
- `name`: CodeAlmanac
- `git`: https://github.com/AlmanacCode/codealmanac
- `category`: ai
- `description`: Self-updating repo wiki for AI coding agents.
