### PR TITLE
Add rotate (security)

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2229,3 +2229,4 @@ file-handling,doxx,,https://github.com/bgreenwell/doxx,"Terminal native document
 online,IMDb Terminal Browser,,https://github.com/isene/IMDB,Ruby-based terminal application for discovering and managing movies and TV series from IMDb's Top lists.
 online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program allows you to manage and read content from various popular platforms without having to use a browser or separate apps.
 cheatsheet,mdpick,,https://github.com/toolleeo/mdpick,"A terminal user interface (TUI) tool for interactively selecting and extracting code blocks or links from Markdown files and copy them to the clipboard, ready for being pasted right in the command line or anywhere else, or a tmux pane."
+security,rotate,,https://github.com/yangsi7/rotate-env,Bulk-rotate a leaked API-key env variable across every .env and .mcp.json file without ever printing the secret.


### PR DESCRIPTION
Adds one row to `data/apps.csv` (not the generated README) under the `security` category.

**rotate** — https://github.com/yangsi7/rotate-env — is a small MIT-licensed CLI that bulk-rotates the value of a named API-key env variable across every `.env`, `.env.*`, `.envrc`, and `.mcp.json` file found recursively from where you run it. It previews as a masked dry-run by default, never puts the secret on argv or prints it, and writes atomically. Handy when a key leaks into many project config files and has to be replaced everywhere at once.

Row added:

```
security,rotate,,https://github.com/yangsi7/rotate-env,Bulk-rotate a leaked API-key env variable across every .env and .mcp.json file without ever printing the secret.
```

Single line, 5 columns matching the header, description ends with a period. Left the README untouched per CONTRIBUTING.