### PR TITLE
Add nika to ai category

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2222,6 +2222,7 @@ git,WRKFLW,,https://github.com/bahdotsh/wrkflw,"Command-line tool for validating
 security,secret_share,,https://github.com/scosman/secret_share,The program allows you to share messages (secrets and passwords) securely with a CLI.
 shells,sshrc,,https://github.com/cdown/sshrc,The program works just like ssh while also sourcing your local sshrc configuration file upon logging in remotely.
 ai,AskOra,,https://github.com/rosettadb/askora,"Unified Python CLI interacting with multiple AI providers sending prompts and getting structured AI responses, all from your terminal."
+ai,nika,https://nika.sh,https://github.com/supernovae-st/nika,"Workflow engine for AI: reviewable YAML DAGs, statically checked (schema, permits, cost floor) before execution, tamper-evident traces after."
 todo-manager,Togo,,https://github.com/prime-run/togo,A fast and simple terminal-based task and todo manager built in go.
 security,keeenv,,https://github.com/scross01/keeenv,Command-line tool that populates environment variables from a local configuration file with encrypted Keepass database to dynamically fetch sensitive data.
 todo-manager,rusk,,https://github.com/tagirov/rusk,A minimal cross-platform terminal task manager.


### PR DESCRIPTION
One CSV row in data/apps.csv (ai category, per the README rule: edit the CSV, not the README). nika is an open-source (AGPL, Rust) workflow engine for AI — .nika.yaml DAGs statically checked before execution (schema, permits, cost floor), tamper-evident traces after. Description quoted (commas inside field, matching the house convention). Disclosure: I am the nika author (first-party submission).