### PR TITLE
Add SAGE CLI

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2160,6 +2160,7 @@ time-tracker,Hammerclock,,https://github.com/itworks99/hammerclock,TUI chess clo
 ai,CarthageAI,,https://github.com/alaadotcom/CarthageAI,Multi-provider AI terminal assistant for developers and AI enthusiasts.
 data-management-json,Konfigo,,https://github.com/ebogdum/konfigo,"Command-line tool designed to work with multiple configuration file formats like JSON, YAML, TOML."
 ai,Browser CLI,,https://github.com/browsemake/browser-cli,AI agent browser automation tool.
+ai,SAGE,https://github.com/PsYcGoD/sage,https://github.com/PsYcGoD/sage,Local-first CLI wrapper for AI coding agents that records command history locally and returns compressed terminal output.
 copilot,Smart-Shell,,https://github.com/Lusan-sapkota/smart-shell,Intelligent terminal assistant that converts natural language into executable Bash or Zsh commands using Gemini AI model via google-genai SDK.
 email,gmailtail,,https://github.com/c4pt0r/gmailtail,"Command-line tool to monitor Gmail messages and output the as JSON; The program in designed for automation, monitoring and integration with other tools."
 file-dir-cleanup,Duplito,,https://github.com/ftarlao/duplito,Command-line tool designed to help you identify duplicate file on your system by listing the files in folders like ls does and highlighting what is duplicate.


### PR DESCRIPTION
Adds SAGE to data/apps.csv under the AI category.\n\nThe entry is limited to a single CSV row and uses a neutral description of the CLI wrapper.