### PR TITLE
Add ditto

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2229,3 +2229,4 @@ file-handling,doxx,,https://github.com/bgreenwell/doxx,"Terminal native document
 online,IMDb Terminal Browser,,https://github.com/isene/IMDB,Ruby-based terminal application for discovering and managing movies and TV series from IMDb's Top lists.
 online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program allows you to manage and read content from various popular platforms without having to use a browser or separate apps.
 cheatsheet,mdpick,,https://github.com/toolleeo/mdpick,"A terminal user interface (TUI) tool for interactively selecting and extracting code blocks or links from Markdown files and copy them to the clipboard, ready for being pasted right in the command line or anywhere else, or a tmux pane."
+ai,ditto,,https://github.com/ohad6k/ditto,"Mines your local AI coding session logs (Claude Code, Codex, Copilot CLI, OpenCode) into a personal working profile your agent loads before every task."


### PR DESCRIPTION
Adds one row to data/apps.csv (ai category) for ditto, a command-line tool that mines local AI coding session logs (Claude Code, Codex, Copilot CLI, OpenCode) into a personal working profile the agent loads before every task. Single stdlib-only Python file, MIT-licensed, runs entirely locally. CSV only, README untouched, per the contribution rules. I am the author.