### PR TITLE
Add whatsapp-chat-to-pdf to office CLI apps

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -1,4 +1,5 @@
 category,name,homepage,git,description
+office,whatsapp-chat-to-pdf,https://github.com/generalistprogrammer/whatsapp-chat-to-pdf,https://github.com/generalistprogrammer/whatsapp-chat-to-pdf,"Convert exported WhatsApp chats to styled PDFs offline from a Python or Node CLI."
 programming,termfu,,https://github.com/jvalcher/termfu,A multi-language debugger frontend that allows users to create and switch between custom layouts.
 productivity,h-m-m,,https://github.com/nadrad/h-m-m,"h-m-m (pronounced like the interjection ""hmm"") is a simple, fast, keyboard-centric terminal-based tool for working with mind maps."
 productivity,telert,https://github.com/navig-me/telert,https://github.com/navig-me/telert,"Lightweight CLI and Python utility that sends alerts (Telegram, Slack, Teams, Desktop, Audio) when commands complete."


### PR DESCRIPTION
Adds one MIT-licensed, cross-platform CLI that converts exported WhatsApp `_chat.txt` or `.zip` files to styled PDFs. It is installable from PyPI or npm, runs offline, and has CI plus a public synthetic compatibility benchmark.

Disclosure: I maintain the suggested project. I have added one schema-compatible row to `data/apps.csv` and have not edited the generated README.

No payment, reciprocal link, or commercial anchor text is requested.
