### PR TITLE
add: citecheck

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2229,3 +2229,4 @@ file-handling,doxx,,https://github.com/bgreenwell/doxx,"Terminal native document
 online,IMDb Terminal Browser,,https://github.com/isene/IMDB,Ruby-based terminal application for discovering and managing movies and TV series from IMDb's Top lists.
 online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program allows you to manage and read content from various popular platforms without having to use a browser or separate apps.
 cheatsheet,mdpick,,https://github.com/toolleeo/mdpick,"A terminal user interface (TUI) tool for interactively selecting and extracting code blocks or links from Markdown files and copy them to the clipboard, ready for being pasted right in the command line or anywhere else, or a tmux pane."
+science,citecheck,,https://github.com/tobiasosDev/citecheck,"Checks whether the references in a .bib/.ris/CSL-JSON bibliography exist and haven't been retracted, using the Crossref, OpenAlex, and DOAJ APIs."


### PR DESCRIPTION
citecheck is a command-line tool that verifies the references in a .bib/.ris/CSL-JSON bibliography actually exist and haven't been retracted, checking them against the public Crossref, OpenAlex, and DOAJ APIs. No API key or signup required, and it works directly on exports from Zotero, Mendeley, or EndNote.

It's open-source (MIT licensed) and actively maintained (npm package `citecheck`, currently v1.2.0). Added to `data/apps.csv` under the `science` category only, per the contribution guidelines.