### PR TITLE
Add llm-tokencheck CLI

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2222,6 +2222,7 @@ git,WRKFLW,,https://github.com/bahdotsh/wrkflw,"Command-line tool for validating
 security,secret_share,,https://github.com/scosman/secret_share,The program allows you to share messages (secrets and passwords) securely with a CLI.
 shells,sshrc,,https://github.com/cdown/sshrc,The program works just like ssh while also sourcing your local sshrc configuration file upon logging in remotely.
 ai,AskOra,,https://github.com/rosettadb/askora,"Unified Python CLI interacting with multiple AI providers sending prompts and getting structured AI responses, all from your terminal."
+ai,llm-tokencheck,https://www.npmjs.com/package/llm-tokencheck,https://github.com/ilan-lachkar/llm-tokencheck,"Estimates LLM API token count and USD cost for a file or text across Anthropic, OpenAI and Google models before you send the request."
 todo-manager,Togo,,https://github.com/prime-run/togo,A fast and simple terminal-based task and todo manager built in go.
 security,keeenv,,https://github.com/scross01/keeenv,Command-line tool that populates environment variables from a local configuration file with encrypted Keepass database to dynamically fetch sensitive data.
 todo-manager,rusk,,https://github.com/tagirov/rusk,A minimal cross-platform terminal task manager.


### PR DESCRIPTION
Adds llm-tokencheck to data/apps.csv under the AI / ChatGPT category.

llm-tokencheck is a free, open-source CLI that estimates token count and USD cost for a file or text across Anthropic, OpenAI and Google models before you send the API request.

Repository: https://github.com/ilan-lachkar/llm-tokencheck
Homepage: https://www.npmjs.com/package/llm-tokencheck