### PR TITLE
Add golazo

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2230,3 +2230,4 @@ file-handling,doxx,,https://github.com/bgreenwell/doxx,"Terminal native document
 online,IMDb Terminal Browser,,https://github.com/isene/IMDB,Ruby-based terminal application for discovering and managing movies and TV series from IMDb's Top lists.
 online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program allows you to manage and read content from various popular platforms without having to use a browser or separate apps.
 cheatsheet,mdpick,,https://github.com/toolleeo/mdpick,"A terminal user interface (TUI) tool for interactively selecting and extracting code blocks or links from Markdown files and copy them to the clipboard, ready for being pasted right in the command line or anywhere else, or a tmux pane."
+online,golazo,https://thegolazo.app,https://github.com/0xjuanma/golazo,The beautiful game in your terminal. Minimal TUI app to keep up with live and recent football/soccer matches.


### PR DESCRIPTION
## Summary
Adds an entry for golazo, a TUI app for following live and recent football/soccer matches.

repo: https://github.com/0xjuanma/golazo
website: https://thegolazo.app
