### PR TITLE
Add CSV Row Realigner

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2230,3 +2230,4 @@ file-handling,doxx,,https://github.com/bgreenwell/doxx,"Terminal native document
 online,IMDb Terminal Browser,,https://github.com/isene/IMDB,Ruby-based terminal application for discovering and managing movies and TV series from IMDb's Top lists.
 online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program allows you to manage and read content from various popular platforms without having to use a browser or separate apps.
 cheatsheet,mdpick,,https://github.com/toolleeo/mdpick,"A terminal user interface (TUI) tool for interactively selecting and extracting code blocks or links from Markdown files and copy them to the clipboard, ready for being pasted right in the command line or anywhere else, or a tmux pane."
+data-management-tabular,CSV Row Realigner,,https://github.com/zhailong8845-art/csv-row-realigner,"Repairs CSV rows shifted by unquoted delimiters, normalizes dates, and audits record preservation."


### PR DESCRIPTION
Adds CSV Row Realigner to the tabular data category.

The tool repairs rows shifted by unquoted delimiters in a known text field, normalizes dates, and emits an audit report that verifies record and unique-ID preservation. It is an offline Python CLI with no runtime dependencies and an MIT license.

Validation:
- Changed only `data/apps.csv`, as required
- Parsed the full CSV with Python `csv.DictReader` (2,232 entries)
- Confirmed exactly one new entry with the expected category and clonable Git URL
- `git diff --check` passes