### PR TITLE
Add Kane CLI

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2230,3 +2230,4 @@ file-handling,doxx,,https://github.com/bgreenwell/doxx,"Terminal native document
 online,IMDb Terminal Browser,,https://github.com/isene/IMDB,Ruby-based terminal application for discovering and managing movies and TV series from IMDb's Top lists.
 online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program allows you to manage and read content from various popular platforms without having to use a browser or separate apps.
 cheatsheet,mdpick,,https://github.com/toolleeo/mdpick,"A terminal user interface (TUI) tool for interactively selecting and extracting code blocks or links from Markdown files and copy them to the clipboard, ready for being pasted right in the command line or anywhere else, or a tmux pane."
+programming,Kane CLI,https://www.testmuai.com/kane-cli/,,Runs browser tests described in natural-language objectives in a real browser and reports pass/fail results.


### PR DESCRIPTION
Adds a row for [Kane CLI](https://www.testmuai.com/kane-cli/) to data/apps.csv under the programming category (which covers testing tools), CSV only per your contribution notes. It's a terminal tool that runs browser tests from natural-language objectives and reports pass/fail; homepage URL provided as there's no public clonable repo. Disclosure so you can weigh it accordingly: I work on this tool at TestMu AI — sparshk@testmuai.com.