### PR TITLE
Add light-ocr

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -1,4 +1,5 @@
 category,name,homepage,git,description
+graphics,light-ocr,https://www.npmjs.com/package/@arcships/light-ocr,https://github.com/arcships/light-ocr,"Fast, offline OCR for images with text, confidence scores, and coordinates; ships as a self-contained Node.js package and command for macOS, Linux, and Windows."
 programming,termfu,,https://github.com/jvalcher/termfu,A multi-language debugger frontend that allows users to create and switch between custom layouts.
 productivity,h-m-m,,https://github.com/nadrad/h-m-m,"h-m-m (pronounced like the interjection ""hmm"") is a simple, fast, keyboard-centric terminal-based tool for working with mind maps."
 productivity,telert,https://github.com/navig-me/telert,https://github.com/navig-me/telert,"Lightweight CLI and Python utility that sends alerts (Telegram, Slack, Teams, Desktop, Audio) when commands complete."


### PR DESCRIPTION
## Summary

Adds [light-ocr](https://github.com/arcships/light-ocr) to the `graphics` category. light-ocr is a fast, offline OCR command for images that returns text, confidence scores, and coordinates. The npm package is self-contained and supports macOS, Linux, and Windows.

## Validation

- Changed `data/apps.csv` only, as required.
- Parsed the complete CSV successfully (2,232 data rows).
- Confirmed there is exactly one `light-ocr` entry.