### PR TITLE
Add whatbroke

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2230,3 +2230,4 @@ file-handling,doxx,,https://github.com/bgreenwell/doxx,"Terminal native document
 online,IMDb Terminal Browser,,https://github.com/isene/IMDB,Ruby-based terminal application for discovering and managing movies and TV series from IMDb's Top lists.
 online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program allows you to manage and read content from various popular platforms without having to use a browser or separate apps.
 cheatsheet,mdpick,,https://github.com/toolleeo/mdpick,"A terminal user interface (TUI) tool for interactively selecting and extracting code blocks or links from Markdown files and copy them to the clipboard, ready for being pasted right in the command line or anywhere else, or a tmux pane."
+diff,whatbroke,,https://github.com/arthi-arumugam-git/whatbroke,"Diffs two trace files of an AI agent's runs to show what changed in tool calls, arguments, cost, latency, and outcomes, with multi-sample flake detection."


### PR DESCRIPTION
Adds whatbroke to data/apps.csv under the diff category. It diffs two trace files of an AI agent's runs and reports what changed in tool calls, arguments, cost, latency, and outcomes, with multi-sample flake detection. MIT licensed, on npm as whatbroke-cli. Only the CSV file is changed, per the contribution instructions. Happy to adjust the category or description if you prefer.