### PR TITLE
Add mdcli (MultiDrive) to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -2468,6 +2468,7 @@ Miscellaneous utilities that are not do not fit in other categories and they are
 * [guesswidth](https://github.com/noborus/guesswidth) - Guess the width output without delimiters in commands that output to the terminal.
 * [Keep](https://github.com/keephq/keep) - Simple alerting tool, with declarative syntax and builtin providers.
 * [loopctl](https://github.com/Karvy-Singh/loopctl) - The program allows you to repeat a media/section of media x number of times and to repeat a certain part of media.
+* [mdcli](https://multidrive.io) - CLI version of MultiDrive for drive backup, cloning, and erasing
 * [mkdesk](https://gitlab.com/mr-draxs/mkdesk) - A program/command to create .desktop files (program launchers) using the terminal.
 * [movie](https://github.com/mayankchd/movie) - A CLI for getting information about a movie and comparing two movies.
 * [moviemon](https://github.com/iCHAIT/moviemon) - A Python program that displays all the information about all your movies in the command line.


### PR DESCRIPTION
This utility that can be used in scripts and other automation  processes when processing drives. Here are a few examples:

```
mdcli backup d2 d:\image.zip           
# Backup the 2nd shown drive

mdcli.exe erase d3 --pattern ABCD   
# Erase the 3rd drive with 0xABCD pattern

mdcli clone d3 d4 -b 500M -c 1T -m 
# Clone 1 TB from Drive #3 with the offset of 500 MB to a target Drive #4, mount Drive #4 to Windows after cloning is complete
```