### PR TITLE
Add dnafile CLI

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -960,6 +960,7 @@ file-handling,ForkFS,,https://github.com/SUPERCILEX/forkfs,ForkFS allows you to 
 organizers,icsp,,https://github.com/loteoo/icsp,Command-line iCalendar (.ics) to CSV utility.
 ai,HAL 2023,,https://github.com/Brutuski/hal2023-cli,"Inspired by the infamous HAL9000, it is a simple script to chat with OpenAI's ChatGPT."
 science,GCTU,,https://github.com/Mandrew0822/GCTU---Genetic-code-translation-utility,A simple command line tool which allows one to convert DNA code sequences to the different RNA sequences.
+science,dnafile,,https://github.com/AndreySoloviev/dnafile,"Reads raw DNA exports from 23andMe, AncestryDNA, MyHeritage, FamilyTreeDNA and LivingDNA: detects the service and array, counts markers, checks whether given rsIDs are covered, and normalizes any of them to one layout. Works fully offline."
 organizers,Girok,,https://github.com/noisrucer/girok,A powerful and beautiful CLI scheduler.
 system,killport,,https://github.com/jkfran/killport,A command-line tool to easily kill processes running on a specified port.
 copilot,CLI Co-Pilot,,https://github.com/AntonOsika/CLI-Co-Pilot,CLI tool that uses GPT4 to turn natural language commands into their Bash/ZShell/PowerShell equivalents.


### PR DESCRIPTION
Adds one entry to `data/apps.csv` under **science**. Per CONTRIBUTING I've changed the CSV only and left `README.md` for you to regenerate.

```
science,dnafile,,https://github.com/AndreySoloviev/dnafile,"Reads raw DNA exports from 23andMe, AncestryDNA, MyHeritage, FamilyTreeDNA and LivingDNA: ..."
```

**What it does:** reads the raw data files that consumer genetic-testing services let you export. Four subcommands — `detect` (which service and array produced this file), `stats` (marker census), `check` (whether specific rsIDs are actually present), `normalize` (one TSV/JSON layout regardless of which service it came from). Takes plain text, `.gz`, `.zip`, or stdin.

**Why it might suit the list:** it's a single-purpose Unix-shaped tool. Output is plain columns, `normalize` writes to stdout with the marker count sent to stderr so it never contaminates a pipe, and the exit codes are meaningful — `0` markers present, **`2` coverage insufficient to answer**, `1` the tool itself failed. So "this file cannot answer your question" and "you invoked me wrong" are distinguishable in a script:

```bash
if dnafile check genome.txt --panel apoe >/dev/null; then
  echo "both sites covered"
else
  echo "not answerable from this file"
fi
```

That distinction is the point of the tool. Some results need two markers and the arrays don't reliably carry both — asked for an APOE ε-status from a file holding one of the pair, it reports `insufficient markers` instead of emitting a number that looks the same as a real one.

**Practical:** single static Go binary, `go install github.com/AndreySoloviev/dnafile/cmd/dnafile@latest`, no dependencies outside the Go standard library, MIT licensed, tests green.

It makes **no network calls at all** — enforced by a test that walks the transitive import graph of every package and fails if anything network-capable is reachable, not merely asserted in the README. Given the input file identifies a person, that seemed worth making checkable.

**Disclosure:** I'm the author. Happy to adjust the description or category, or withdraw if it's not a fit.
