### PR TITLE
Add lacuna CLI (music)

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2206,3 +2206,4 @@ online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program all
 cheatsheet,mdpick,,https://github.com/toolleeo/mdpick,"A terminal user interface (TUI) tool for interactively selecting and extracting code blocks or links from Markdown files and copy them to the clipboard, ready for being pasted right in the command line or anywhere else, or a tmux pane."
 learning,bashquest,,https://github.com/toolleeo/bashquest,Shell quest (Capture-The-Flag-style): a didactic game to train/teach common Unix shell commands.
 games,cli.poker,https://www.cli.poker,,Multiplayer Texas Hold'em poker played in the terminal over SSH. Just run `ssh cli.poker`.
+music,lacuna,https://lacuna.fm,https://github.com/JOYLINK-LTD/lacuna-toolkit,"Official CLI for the Lacuna Music API: generate AI music (full songs with vocals and lyrics, or instrumentals), poll task status, and download the audio. Installable from npm."


### PR DESCRIPTION
Adds the `lacuna` CLI to the music category in `data/apps.csv` (CSV only, README untouched per CONTRIBUTING).

- name: lacuna — official CLI for the [Lacuna](https://lacuna.fm) Music API
- git: https://github.com/JOYLINK-LTD/lacuna-toolkit (open-source TypeScript monorepo; also ships an SDK and MCP server)
- What it does: generate AI music from the terminal — full songs with vocals and lyrics, or instrumentals — poll task status, and download the resulting audio. Published on npm (package `lacuna-toolkit`, binary `lacuna`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)