### PR TITLE
Add OutageDeck

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2206,3 +2206,4 @@ online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program all
 cheatsheet,mdpick,,https://github.com/toolleeo/mdpick,"A terminal user interface (TUI) tool for interactively selecting and extracting code blocks or links from Markdown files and copy them to the clipboard, ready for being pasted right in the command line or anywhere else, or a tmux pane."
 learning,bashquest,,https://github.com/toolleeo/bashquest,Shell quest (Capture-The-Flag-style): a didactic game to train/teach common Unix shell commands.
 games,cli.poker,https://www.cli.poker,,Multiplayer Texas Hold'em poker played in the terminal over SSH. Just run `ssh cli.poker`.
+monitor,OutageDeck,https://outagedeck.com,https://github.com/outagedeck/cli,Checks current status for 170+ cloud and SaaS providers from official vendor feeds with JSON output and configurable CI exit thresholds.


### PR DESCRIPTION
Adds the open-source OutageDeck status CLI to the monitoring category. It checks cloud and SaaS provider status published through official machine-readable vendor feeds, supports JSON output and status-threshold exit codes, and installs through Homebrew or Go. I maintain OutageDeck; the public v0.1.0 release has been tested on macOS and Linux artifacts. This changes only data/apps.csv as requested by the contribution guide.