### PR TITLE
Add cwal

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -1670,6 +1670,7 @@ system,shournal,,https://github.com/tycho-kirchner/shournal,Log shell-commands a
 text-processing,hburger,,https://github.com/niqodea/hburger,Shorten long strings and paths while preserving readability.
 text-search,zfind,,https://github.com/laktak/zfind,Search for files (even inside tar/zip/7z/rar) using a SQL-WHERE filter.
 graphics,gowall,,https://github.com/Achno/gowall,"A tool to convert a Wallpaper's color scheme / palette, image to pixel art, color palette extraction, image upsacling with Adversarial Networks  and more image processing features."
+graphics,cwal,,https://github.com/nitinbhat972/cwal,"Blazing-fast pywal-like color palette generator written in C."
 utility,sisi,,https://github.com/frost-beta/sisi,Semantic image search CLI tool.
 animation,rich_life,,https://github.com/paulrobello/rich_life,Conway's Game of Life and Langton's Ant.
 system,sysz,,https://github.com/joehillen/sysz,fzf terminal UI for systemctl.


### PR DESCRIPTION
Add cwal, a high-performance wallpaper-based color scheme generator written in C. It extracts color palettes from images, applies them using a flexible template system, and supports Lua-based customization. It serves as a fast, lightweight alternative to tools like pywal while supporting multiple output formats and desktop environments.