### PR TITLE
Add claude-session-tint to terminal

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2062,6 +2062,7 @@ browser,ELinks,http://elinks.cz/,https://github.com/rkd77/elinks,"Fork of ELinks
 torrent,nyaa,,https://github.com/Beastwick18/nyaa,A nyaa TUI for browsing and downloading torrents.
 online,tblogs,,https://github.com/ezeoleaf/tblogs,Read and browse development blogs with this TUI from your terminal.
 terminal,Textual Web,,https://github.com/Textualize/textual-web,Run TUIs and terminals in your browser.
+terminal,claude-session-tint,,https://github.com/dotcomjack/claude-session-tint,"Colours each macOS Terminal.app window by project and brightens the one whose Claude Code session finished while it was unfocused, clearing it again on focus."
 data-management,chndlr,,https://github.com/bharatvaj/chndlr,Replacement for xdg-open; It determines the appropriate application to open a file or URL based on user-defined rules in configuration.
 ai,Elroy,,https://github.com/elroy-bot/elroy,AI personal assistant that remembers and sets goals.
 programming,QuickStart,,https://github.com/squach90/homebrew-quickstart,"CLI to quickly create projects in HTML, Python, Node_js, Bash and more."


### PR DESCRIPTION
Adds [claude-session-tint](https://github.com/dotcomjack/claude-session-tint) to the `terminal` category, which is described as terminal emulators and related tools.

It colours each macOS Terminal.app window by project and brightens whichever one finished work while it was unfocused, dropping back on focus. Useful when several terminal sessions are running at once and the window body is the only ambient signal available.

Changed `data/apps.csv` only, not the README, per CONTRIBUTING. Verified the file still parses cleanly and the row count went from 2207 to 2208. MIT, macOS, no network calls.