### PR TITLE
Add llm-ctxpack (ai category)

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2206,3 +2206,4 @@ online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program all
 cheatsheet,mdpick,,https://github.com/toolleeo/mdpick,"A terminal user interface (TUI) tool for interactively selecting and extracting code blocks or links from Markdown files and copy them to the clipboard, ready for being pasted right in the command line or anywhere else, or a tmux pane."
 learning,bashquest,,https://github.com/toolleeo/bashquest,Shell quest (Capture-The-Flag-style): a didactic game to train/teach common Unix shell commands.
 games,cli.poker,https://www.cli.poker,,Multiplayer Texas Hold'em poker played in the terminal over SSH. Just run `ssh cli.poker`.
+ai,llm-ctxpack,https://www.npmjs.com/package/llm-ctxpack,https://github.com/dacode-dev/llm-ctxpack,"Packs a repo into LLM-ready context: git-diff-aware and token-budget-aware, with automatic secret redaction, unlike full-dump tools."


### PR DESCRIPTION
Adds `llm-ctxpack`, a CLI that packs a repo into LLM-ready context (git-diff-aware, token-budget-aware, with secret redaction). Published on npm: https://www.npmjs.com/package/llm-ctxpack. Source: https://github.com/dacode-dev/llm-ctxpack. Follows CONTRIBUTING.md: edited only data/apps.csv, one new row in the `ai` category.